### PR TITLE
Fixed compilation on Fedora 34

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Rebuild
+    - name: Rebuild Fedora 34
+      run: npx --package mini-cross@0.15.2 mc --no-tty fedora:34 .mc/rebuild.sh
+
+    - name: Rebuild Ubuntu 20.04
       run: npx --package mini-cross@0.15.2 mc --no-tty ubuntu:20.04 .mc/rebuild.sh
 

--- a/.mc/fedora:34.yaml
+++ b/.mc/fedora:34.yaml
@@ -1,0 +1,21 @@
+---
+base: fedora:34
+install:
+ - gcc
+ - gcc-c++
+ - make
+
+ # Build dependencies
+ - autoconf
+ - gettext-devel
+ - libtool
+ - pkgconf
+
+ # Runtime dependencies
+ - cairo-devel
+ - gtk2-devel
+ - libdxflib-devel
+
+ # Test dependencies
+ - ImageMagick
+---

--- a/.mc/rebuild.sh
+++ b/.mc/rebuild.sh
@@ -5,6 +5,8 @@
 #
 #     mc fedora:34 .mc/rebuild.sh
 #     mc ubuntu:20.04 .mc/rebuild.sh
+set -e
+
 sh autogen.sh
 
 ./configure					\

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -26,7 +26,7 @@
     \ingroup gerbv
 */
 
-enum {
+typedef enum {
 	CALLBACKS_SAVE_PROJECT_AS,
 	CALLBACKS_SAVE_FILE_PS,
 	CALLBACKS_SAVE_FILE_PDF,
@@ -43,7 +43,7 @@ enum {
 	
 } CALLBACKS_SAVE_FILE_TYPE;
 
-enum {
+typedef enum {
 	LAYER_SELECTED =	-1,
 	LAYER_ALL_ON =		-2,
 	LAYER_ALL_OFF =		-3,

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -65,10 +65,6 @@ For help with using the standalone Gerbv software, please refer to the man page
 #ifndef __GERBV_H__
 #define __GERBV_H__
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -80,6 +76,10 @@ extern "C" {
 
 #ifndef RENDER_USING_GDK
 # include <cairo.h>
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
 #endif
 
 #define APERTURE_MIN 10


### PR DESCRIPTION
* `gerbv.h` specified `"C"` linkage for includes, which will fail on transitive C++ includes
* `callbacks.h` did not `typedef enum` definitions, thus causing a link failure due to multiple definitions