### PR TITLE
Use automatic version for CI builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with this program; if not, write to the Free Software
 dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 
-AC_INIT([gerbv], [2.7A])
+AC_INIT([gerbv], [m4_esyscmd(utils/git-version-gen.sh 2.7A)])
 AC_CONFIG_SRCDIR([src/gerbv.c])
 AC_PREREQ([2.59])
 AM_INIT_AUTOMAKE([1.9])

--- a/utils/git-version-gen.sh
+++ b/utils/git-version-gen.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Generates gerbv version string from a given prefix and the current commit
+# short id
+#
+# @warning Version will only be updated when reconfiguring! Will have no effect
+#     on incremental builds
+#
+# @param $1 Version prefix
+
+set -e
+
+
+# Validate arguments
+PREFIX="${1}"
+
+if [ "" == "${PREFIX}" ]; then
+	(>&2 echo "Usage: git-version-gen.sh <prefix>")
+	exit 1
+fi
+
+
+# Validate environment
+GIT=`command -v git`
+
+if [ ! -x "${GIT}" ]; then
+	(>&2 echo "\`git' missing")
+	exit 1
+fi
+
+
+# Get commit short id
+RELEASE_COMMIT=`"${GIT}" rev-parse HEAD`
+RELEASE_COMMIT_SHORT="${RELEASE_COMMIT:0:6}"
+
+
+# Output final version
+echo -n "${PREFIX}~${RELEASE_COMMIT_SHORT}"
+


### PR DESCRIPTION
In order to differentiate automatically generated builds, I have attached the git short commit id to the version. This will not be present for releases.