### PR TITLE
Crash may occur on opening/saveing files

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -564,6 +564,8 @@ get_value_string(scheme *sc, pointer value)
 static char *
 convert_path_separators(char* path, int conv_flag)
 {
+    if (path == NULL) return NULL;
+
 #if defined (__MINGW32__)        
     char     *hit_in_path;
 


### PR DESCRIPTION
This is caused by passing `NULL` to `strchr()` function.
Behavior of `strchr(NULL, c)` is implementation-dependent.
Indeed, MinGW-w64 gcc crashes if `strchr(NULL, c)` is executed.

See [SourceForce patch #83](https://sourceforge.net/p/gerbv/patches/83/)

```diff
--- a/src/project.c	2020-10-22 07:12:44.000000000 +0900
+++ b/src/project.c	2021-08-03 22:15:56.700404900 +0900
@@ -564,6 +564,7 @@ get_value_string(scheme *sc, pointer val
 static char *
 convert_path_separators(char* path, int conv_flag)
 {
+	if (path == NULL) return NULL;
 #if defined (__MINGW32__)        
     char     *hit_in_path;
```