### PR TITLE
Add library function to explicitly load drill file

### DIFF
--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -615,6 +615,24 @@ gerbv_open_image(gerbv_project_t *gerbvProject, char *filename, int idx, int rel
     return retv;
 } /* open_image */
 
+/* ------------------------------------------------------------------ */
+gerbv_image_t *
+gerbv_create_excellon_image_from_filename (gchar *filename){
+   gerbv_image_t *returnImage;
+   gerb_file_t *fd;
+
+   fd = gerb_fopen(filename);
+   if (fd == NULL) {
+       GERB_MESSAGE("Trying to open %s: %s\n", filename, strerror(errno));
+       return NULL;
+   }
+   gchar *currentLoadDirectory = g_path_get_dirname (filename);
+   returnImage = parse_drillfile(fd, (gerbv_HID_Attribute*)currentLoadDirectory, 0, 0);
+   g_free (currentLoadDirectory);
+   gerb_fclose(fd);
+   return returnImage;
+} /* gerbv_create_excellon_image_from_filename */
+
 gerbv_image_t *
 gerbv_create_rs274x_image_from_filename (gchar *filename){
 	gerbv_image_t *returnImage;

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -981,6 +981,12 @@ gerbv_export_dxf_file_from_image (const gchar *filename, /*!< the filename for t
 		gerbv_user_transformation_t *transform /*!< the transformation to apply before exporting */
 );
 
+//! Parse a Excellon drill file and return the parsed image
+//! \return the new gerbv_image_t, or NULL if not successful
+gerbv_image_t *
+gerbv_create_excellon_image_from_filename (gchar *filename /*!< the filename of the file to be parsed*/
+);
+
 //! Parse a RS274X file and return the parsed image
 //! \return the new gerbv_image_t, or NULL if not successful
 gerbv_image_t *


### PR DESCRIPTION
This has been missing for some reason and not having this function is very inconvinient.

See [SourceForge patch #73](https://sourceforge.net/p/gerbv/patches/73/)

```patch
From d3797158db49b838d3a4be16c23fe0213cec8f92 Mon Sep 17 00:00:00 2001
From: Mirai Computing <mirai.computing@gmail.com>
Date: Tue, 17 Sep 2019 21:39:22 +0300
Subject: [PATCH 2/2] Explicitly load drill file

---
 src/gerbv.c | 17 +++++++++++++++++
 src/gerbv.h |  6 ++++++
 2 files changed, 23 insertions(+)

diff --git a/src/gerbv.c b/src/gerbv.c
index 26d0b43..c0469a2 100644
--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -616,6 +616,23 @@ gerbv_open_image(gerbv_project_t *gerbvProject, char *filename, int idx, int rel
 } /* open_image */
 
 gerbv_image_t *
+gerbv_create_excellon_image_from_filename (gchar *filename){
+   gerbv_image_t *returnImage;
+   gerb_file_t *fd;
+
+   fd = gerb_fopen(filename);
+   if (fd == NULL) {
+           GERB_MESSAGE("Trying to open %s: %s\n", filename, strerror(errno));
+           return NULL;
+   }
+   gchar *currentLoadDirectory = g_path_get_dirname (filename);
+   returnImage = parse_drillfile(fd, (gerbv_HID_Attribute*)currentLoadDirectory, 0, 0);
+   g_free (currentLoadDirectory);
+   gerb_fclose(fd);
+   return returnImage;
+}
+
+gerbv_image_t *
 gerbv_create_rs274x_image_from_filename (gchar *filename){
 	gerbv_image_t *returnImage;
 	gerb_file_t *fd;
diff --git a/src/gerbv.h b/src/gerbv.h
index 26d6492..9ad334a 100644
--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -981,6 +981,12 @@ gerbv_export_dxf_file_from_image (const gchar *filename, /*!< the filename for t
 		gerbv_user_transformation_t *transform /*!< the transformation to apply before exporting */
 );
 
+//! Parse a Excellon drill file and return the parsed image
+//! \return the new gerbv_image_t, or NULL if not successful
+gerbv_image_t *
+gerbv_create_excellon_image_from_filename (gchar *filename /*!< the filename of the file to be parsed*/
+);
+
 //! Parse a RS274X file and return the parsed image
 //! \return the new gerbv_image_t, or NULL if not successful
 gerbv_image_t *
-- 
2.13.7
```