### PR TITLE
Correct bounding box calculation for drilled slot.

### DIFF
--- a/src/drill.c
+++ b/src/drill.c
@@ -480,6 +480,12 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 		curr_net->stop_x = state->curr_x;
 		curr_net->stop_y = state->curr_y;
 
+		if (state->unit == GERBV_UNIT_MM) {
+		    /* Convert to inches -- internal units */
+		    curr_net->stop_x /= 25.4;
+		    curr_net->stop_y /= 25.4;
+		}
+
 		r = image->aperture[state->current_tool]->parameter[0]/2;
 
 		/* Update boundingBox with drilled slot stop_x,y coords */
@@ -490,11 +496,6 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 
 		drill_update_image_info_min_max_from_bbox(image->info, bbox);
 
-		if (state->unit == GERBV_UNIT_MM) {
-		    /* Convert to inches -- internal units */
-		    curr_net->stop_x /= 25.4;
-		    curr_net->stop_y /= 25.4;
-		}
 		curr_net->aperture_state = GERBV_APERTURE_STATE_ON;
 
 		break;
@@ -764,7 +765,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	      for (c = 1 ; c <= rcnt ; c++) {
 		state->curr_x = start_x + c*step_x;
 		state->curr_y = start_y + c*step_y;
-		dprintf ("    Repeat #%d — new location is (%g, %g)\n", c, state->curr_x, state->curr_y);
+		dprintf ("    Repeat #%d - new location is (%g, %g)\n", c, state->curr_x, state->curr_y);
 		curr_net = drill_add_drill_hole (image, state, stats, curr_net);
 	      }
 	      


### PR DESCRIPTION
The conversion of units was done in the wrong place leading to the bounding box to be incorrect.  This fixes it.

Also, an em-dash was used instead of a minus character in the file, causing the file to not be ASCII.