### PR TITLE
Set the aperature earlier

### DIFF
--- a/src/drill.c
+++ b/src/drill.c
@@ -1119,6 +1119,7 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
 
     /* Set the current tool to the correct one */
     state->current_tool = tool_num;
+    apert = image->aperture[tool_num];
 
     /* Check for a size definition */
     temp = gerb_fgetc(fd);
@@ -1155,7 +1156,6 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
 			    "at line %ld in file \"%s\""),
 			    size, tool_num, file_line, fd->filename);
 	    } else {
-		apert = image->aperture[tool_num];
 		if (apert != NULL) {
 		    /* allow a redefine of a tool only if the new definition is exactly the same.
 		     * This avoid lots of spurious complaints with the output of some cad


### PR DESCRIPTION
If we never enter the loop on line 1128 then the test on line 1231 is examining a variable which has never been initialized.  This is undefined behavior and was caught by valgrind.

This fixes the following valgrind error:

```
==44371== Conditional jump or move depends on uninitialised value(s)
==44371==    at 0x4053E9A: drill_parse_T_code (drill.c:1232)
==44371==    by 0x4052F17: parse_drillfile (drill.c:782)
==44371==    by 0x4066BCB: gerbv_open_image (gerbv.c:532)
==44371==    by 0x4065E4F: gerbv_open_layer_from_filename (gerbv.c:230)
==44371==    by 0x210C71: GerberImporter::load_file(std::__cxx11::basic_string<char, std::char_traits<char>
==44371==    by 0x3E4E23: do_pcb2gcode(int, char const**) (main.cpp:343)
==44371==    by 0x1DDF22: main (main.cpp:409)
```