### PR TITLE
Remove non ASCII debug output

### DIFF
--- a/src/drill.c
+++ b/src/drill.c
@@ -764,7 +764,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	      for (c = 1 ; c <= rcnt ; c++) {
 		state->curr_x = start_x + c*step_x;
 		state->curr_y = start_y + c*step_y;
-		dprintf ("    Repeat #%d — new location is (%g, %g)\n", c, state->curr_x, state->curr_y);
+		dprintf ("    Repeat #%d - new location is (%g, %g)\n", c, state->curr_x, state->curr_y);
 		curr_net = drill_add_drill_hole (image, state, stats, curr_net);
 	      }
 	      


### PR DESCRIPTION
An em-dash was used instead of a minus character in the file, causing the file to not be ASCII.

Split of from PR #10