### PR TITLE
Build doxygen documentation as part of CI for website

### DIFF
--- a/.mc/website.yaml
+++ b/.mc/website.yaml
@@ -1,6 +1,7 @@
 ---
 base: ubuntu:20.04
 install:
+ - doxygen
  - m4
  - make
 ---

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,4 +42,4 @@ DISTCHECK_CONFIGURE_FLAGS = \
 
 .PHONY: doxygen
 doxygen:
-	doxygen doc/Doxyfile.nopreprocessing
+	PROJECT_NUMBER=@VERSION@ doxygen doc/Doxyfile.nopreprocessing

--- a/doc/Doxyfile.nopreprocessing
+++ b/doc/Doxyfile.nopreprocessing
@@ -31,7 +31,7 @@ PROJECT_NAME           = gerbv
 # This could be handy for archiving the generated documentation or 
 # if some version control system is used.
 
-PROJECT_NUMBER         = 2.7
+PROJECT_NUMBER         = $(PROJECT_NUMBER)
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) 
 # base path where the generated documentation will be put. 

--- a/gerbv.github.io/.gitignore
+++ b/gerbv.github.io/.gitignore
@@ -1,2 +1,3 @@
 !/Makefile
+/doc/
 /index.html

--- a/gerbv.github.io/Makefile
+++ b/gerbv.github.io/Makefile
@@ -4,6 +4,10 @@ all: clean build
 
 .PHONY: clean
 clean:
+	if [ -f 'doc' ]; then		\
+		rm -rf 'doc';		\
+	fi
+
 	if [ -f 'index.html' ]; then	\
 		rm 'index.html';	\
 	fi
@@ -11,5 +15,8 @@ clean:
 
 .PHONY: build
 build:
+	make -C '..' doxygen
+	cp -r '../doc/html' 'doc'
+
 	m4 'index.html.m4' > 'index.html'
 

--- a/gerbv.github.io/index.html.m4
+++ b/gerbv.github.io/index.html.m4
@@ -49,7 +49,7 @@
          <li>Gerbv is a viewer for Gerber RS-274X files, Excellon drill files, and CSV pick-and-place files.</li>
          <li>Gerbv is a native Linux application, and it runs on many common UNIX platforms. A Windows version is also available.</li>
          <li>Gerbv is <a href="http://www.gnu.org/philosophy/free-sw.html">free</a> / <a href="http://www.opensource.org/docs/osd">open-source</a> software.</li>
-         <li>The core functionality of gerbv is located in a separate library (libgerbv), allowing developers to include Gerber parsing/editing/exporting/rendering into other programs</li>
+         <li>The core functionality of gerbv is located in a separate library (<a href="doc">libgerbv</a>), allowing developers to include Gerber parsing/editing/exporting/rendering into other programs</li>
          <li>Gerbv was originally developed as one of the utilities affiliated with the <a href="http://www.geda-project.org/">gEDA project</a>, an umbrella organization dedicated to producing free software tools for electronic design.</li>
        </ul>
 

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -58,7 +58,7 @@ the doc/example-code/ directory in CVS).
 
 For help with using the standalone Gerbv software, please refer to the man page
 (using the command "man gerbv") or go to the Gerbv homepage for documentation
-(http://gerbv.geda-project.org).
+(https://gerbv.github.io/).
 
 */
 


### PR DESCRIPTION
`gerbv.github.io/Makefile` should be migrated to `Makefile.am` to use `@VERSION@`.