### PR TITLE
apply of '#81 Fix casting pointer to different size integer'

### DIFF
--- a/src/scheme.c
+++ b/src/scheme.c
@@ -568,7 +568,7 @@ static int alloc_cellseg(scheme *sc, int n) {
      char *cp;
      long i;
      int k;
-     unsigned int adj=ADJ;
+     uintptr_t adj=ADJ;
 
      if(adj<sizeof(struct cell)) {
        adj=sizeof(struct cell);
@@ -583,8 +583,8 @@ static int alloc_cellseg(scheme *sc, int n) {
 	  i = ++sc->last_cell_seg ;
 	  sc->alloc_seg[i] = cp;
 	  /* adjust in TYPE_BITS-bit boundary */
-	  if((unsigned long)cp%adj!=0) {
-	    cp=(char*)(adj*((unsigned long)cp/adj+1));
+	  if((uintptr_t)cp%adj!=0) {
+	    cp=(char*)(adj*((uintptr_t)cp/adj+1));
 	  }
         /* insert new segment in address order */
 	  newp=(pointer)cp;

--- a/src/scheme.c
+++ b/src/scheme.c
@@ -568,7 +568,7 @@ static int alloc_cellseg(scheme *sc, int n) {
      char *cp;
      long i;
      int k;
-     uintptr_t adj=ADJ;
+     size_t adj=ADJ;
 
      if(adj<sizeof(struct cell)) {
        adj=sizeof(struct cell);
@@ -583,8 +583,8 @@ static int alloc_cellseg(scheme *sc, int n) {
 	  i = ++sc->last_cell_seg ;
 	  sc->alloc_seg[i] = cp;
 	  /* adjust in TYPE_BITS-bit boundary */
-	  if((uintptr_t)cp%adj!=0) {
-	    cp=(char*)(adj*((uintptr_t)cp/adj+1));
+	  if((size_t)cp%adj!=0) {
+	    cp=(char*)(adj*((size_t)cp/adj+1));
 	  }
         /* insert new segment in address order */
 	  newp=(pointer)cp;


### PR DESCRIPTION
apply of '#81 Fix casting pointer to different size integer'
https://sourceforge.net/p/gerbv/patches/81/
as opening a .gvp file on Windows always crash

This and the next one are necessary to work on Windows too.
Follow the PR for #77 Fix double-freeing memory