### PR TITLE
Double free

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -199,7 +199,7 @@ void open_project(char *project_filename)
 
 	/* Update the last folder */
 	g_free (mainProject->path);
-	mainProject->path = project_filename;
+	mainProject->path = g_strdup(project_filename);
 
 	gerbv_unload_all_layers (mainProject);
 	main_open_project_from_filename (mainProject, project_filename);
@@ -2768,7 +2768,7 @@ callbacks_file_drop_event(GtkWidget *widget, GdkDragContext *dc,
 	}
 
 	open_files(fns);
-	g_slist_free(fns);
+	g_slist_free_full(fns, g_free);
 	g_strfreev(uris);
 
 	return TRUE;

--- a/src/scheme.c
+++ b/src/scheme.c
@@ -568,7 +568,7 @@ static int alloc_cellseg(scheme *sc, int n) {
      char *cp;
      long i;
      int k;
-     uintptr_t adj=ADJ;
+     unsigned int adj=ADJ;
 
      if(adj<sizeof(struct cell)) {
        adj=sizeof(struct cell);
@@ -583,8 +583,8 @@ static int alloc_cellseg(scheme *sc, int n) {
 	  i = ++sc->last_cell_seg ;
 	  sc->alloc_seg[i] = cp;
 	  /* adjust in TYPE_BITS-bit boundary */
-	  if((uintptr_t)cp%adj!=0) {
-	    cp=(char*)(adj*((uintptr_t)cp/adj+1));
+	  if((unsigned long)cp%adj!=0) {
+	    cp=(char*)(adj*((unsigned long)cp/adj+1));
 	  }
         /* insert new segment in address order */
 	  newp=(pointer)cp;

--- a/src/scheme.c
+++ b/src/scheme.c
@@ -568,7 +568,7 @@ static int alloc_cellseg(scheme *sc, int n) {
      char *cp;
      long i;
      int k;
-     unsigned int adj=ADJ;
+     uintptr_t adj=ADJ;
 
      if(adj<sizeof(struct cell)) {
        adj=sizeof(struct cell);
@@ -583,8 +583,8 @@ static int alloc_cellseg(scheme *sc, int n) {
 	  i = ++sc->last_cell_seg ;
 	  sc->alloc_seg[i] = cp;
 	  /* adjust in TYPE_BITS-bit boundary */
-	  if((unsigned long)cp%adj!=0) {
-	    cp=(char*)(adj*((unsigned long)cp/adj+1));
+	  if((uintptr_t)cp%adj!=0) {
+	    cp=(char*)(adj*((uintptr_t)cp/adj+1));
 	  }
         /* insert new segment in address order */
 	  newp=(pointer)cp;


### PR DESCRIPTION
apply of '#77 Fix double-freeing memory', only the part that was not already applyed:
https://sourceforge.net/p/gerbv/patches/77/
as opening 2nd or 3th .gvp file on Windows crash


