### PR TITLE
#81 Fix casting pointer to different size integer

### DIFF
--- a/src/scheme.c
+++ b/src/scheme.c
@@ -38,6 +38,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h> /* access() on Linux */
 #endif
+#include <stddef.h>
 
 #if USE_STRCASECMP
 #include <strings.h>
@@ -568,7 +569,7 @@ static int alloc_cellseg(scheme *sc, int n) {
      char *cp;
      long i;
      int k;
-     unsigned int adj=ADJ;
+     size_t adj=ADJ;
 
      if(adj<sizeof(struct cell)) {
        adj=sizeof(struct cell);
@@ -583,8 +584,8 @@ static int alloc_cellseg(scheme *sc, int n) {
 	  i = ++sc->last_cell_seg ;
 	  sc->alloc_seg[i] = cp;
 	  /* adjust in TYPE_BITS-bit boundary */
-	  if((unsigned long)cp%adj!=0) {
-	    cp=(char*)(adj*((unsigned long)cp/adj+1));
+	  if((size_t)cp%adj!=0) {
+	    cp=(char*)(adj*((size_t)cp/adj+1));
 	  }
         /* insert new segment in address order */
 	  newp=(pointer)cp;


### PR DESCRIPTION
`src/scheme.c` has the problem of casting pointers to int of different sizes. This problem becomes apparent in 64-bit compilers.

But changed `uintptr_t` to `size_t` as discussed in Pull Request #20 by @efa

See [SourceForge patch #81](https://sourceforge.net/p/gerbv/patches/81/) by [Hiroshi Yoshikawa](https://sourceforge.net/u/y-hiro/)

```patch
--- a/src/scheme.c	2020-10-22 07:12:44.000000000 +0900
+++ b/src/scheme.c	2021-08-03 22:15:56.721406100 +0900
@@ -568,7 +568,7 @@ static int alloc_cellseg(scheme *sc, int
      char *cp;
      long i;
      int k;
-     unsigned int adj=ADJ;
+     uintptr_t adj=ADJ;
 
      if(adj<sizeof(struct cell)) {
        adj=sizeof(struct cell);
@@ -583,8 +583,8 @@ static int alloc_cellseg(scheme *sc, int
 	  i = ++sc->last_cell_seg ;
 	  sc->alloc_seg[i] = cp;
 	  /* adjust in TYPE_BITS-bit boundary */
-	  if((unsigned long)cp%adj!=0) {
-	    cp=(char*)(adj*((unsigned long)cp/adj+1));
+	  if((uintptr_t)cp%adj!=0) {
+	    cp=(char*)(adj*((uintptr_t)cp/adj+1));
 	  }
         /* insert new segment in address order */
 	  newp=(pointer)cp;
```