### PR TITLE
#77 Fix double-freeing memory

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -199,7 +199,7 @@ void open_project(char *project_filename)
 
 	/* Update the last folder */
 	g_free (mainProject->path);
-	mainProject->path = project_filename;
+	mainProject->path = g_strdup(project_filename);
 
 	gerbv_unload_all_layers (mainProject);
 	main_open_project_from_filename (mainProject, project_filename);
@@ -2768,7 +2768,7 @@ callbacks_file_drop_event(GtkWidget *widget, GdkDragContext *dc,
 	}
 
 	open_files(fns);
-	g_slist_free(fns);
+	g_slist_free_full(fns, g_free);
 	g_strfreev(uris);
 
 	return TRUE;


### PR DESCRIPTION
@efo applied #77 Fix double-freeing memory as opening 2nd or 3th .gvp file on Windows crash

See [SourceForge patch #77](https://sourceforge.net/p/gerbv/patches/77/) by [Hiroshi Yoshikawa](https://sourceforge.net/u/y-hiro/)

---

I created a patch for [#256 Memory Double-Free Problem](https://sourceforge.net/p/gerbv/bugs/256/).
Crash with exception 0xc0000374 or freezing windows symptom will disappear by this patch.

```patch
diff -uprN a/src/callbacks.c b/src/callbacks.c
--- a/src/callbacks.c	2019-01-22 18:01:00.000000000 +0900
+++ b/src/callbacks.c	2020-10-25 11:41:24.592107000 +0900
@@ -199,7 +199,7 @@ void open_project(char *project_filename
 
 	/* Update the last folder */
 	g_free (mainProject->path);
-	mainProject->path = project_filename;
+	mainProject->path = g_strdup(project_filename);
 
 	gerbv_unload_all_layers (mainProject);
 	main_open_project_from_filename (mainProject, project_filename);
@@ -2768,7 +2768,7 @@ callbacks_file_drop_event(GtkWidget *wid
 	}
 
 	open_files(fns);
-	g_slist_free(fns);
+	g_slist_free_full(fns, g_free);
 	g_strfreev(uris);
 
 	return TRUE;
diff -uprN a/src/gerb_file.c b/src/gerb_file.c
--- a/src/gerb_file.c	2019-01-22 18:01:00.000000000 +0900
+++ b/src/gerb_file.c	2020-10-25 11:46:47.041550000 +0900
@@ -108,7 +108,7 @@ gerb_fopen(char const * filename)
     }
 #else
     /* all systems without mmap, not only MINGW32 */
-    fd = g_new(gerb_file_t);
+    fd = g_new(gerb_file_t, 1);
     if (fd == NULL) {
 	return NULL;
     }
```