### PR TITLE
Update references to website in help dialog and export

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1870,11 +1870,12 @@ callbacks_about_activate                     (GtkMenuItem     *menuitem,
 		"Version %s\n"
 		"Compiled on %s at %s\n"
 		"\n"
-		"Gerbv is part of the gEDA Project.\n"
+		"Gerbv was originally developed as part of the gEDA Project "
+		"but is now seperatly maintained.\n"
 		"\n"
 		"For more information see:\n"
-		"  gEDA homepage: http://geda-project.org/\n"
-		"  gEDA Wiki: http://wiki.geda-project.org/"),
+		"  gerbv homepage: https://gerbv.github.io/\n"
+		"  gerbv repository: https://github.com/gerbv/gerbv"),
 		VERSION, __DATE__, __TIME__);
 
 #if GTK_CHECK_VERSION(2,6,0)
@@ -1916,7 +1917,7 @@ callbacks_about_activate                     (GtkMenuItem     *menuitem,
 		a[i] = _(authors_string_array[i]);
 
 	gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG (aboutdialog1), (const gchar **)a);
-	gtk_about_dialog_set_website(GTK_ABOUT_DIALOG (aboutdialog1), "http://gerbv.geda-project.org/");
+	gtk_about_dialog_set_website(GTK_ABOUT_DIALOG (aboutdialog1), "https://gerbv.github.io/");
 	g_free(a);
 
 	g_signal_connect (G_OBJECT(aboutdialog1),"response",

--- a/src/export-rs274x.c
+++ b/src/export-rs274x.c
@@ -223,7 +223,7 @@ gerbv_export_rs274x_file_from_image (const gchar *filename, gerbv_image_t *input
 	fprintf(fd, "G04 This is an RS-274x file exported by *\n");
 	fprintf(fd, "G04 gerbv version %s *\n",VERSION);
 	fprintf(fd, "G04 More information is available about gerbv at *\n");
-	fprintf(fd, "G04 http://gerbv.geda-project.org/ *\n");
+	fprintf(fd, "G04 https://gerbv.github.io/ *\n");
 	fprintf(fd, "G04 --End of header info--*\n");
 	fprintf(fd, "%%MOIN*%%\n");
 	fprintf(fd, "%%FSLAX36Y36*%%\n");


### PR DESCRIPTION
As noted by @eyal0 in [issue #36](https://github.com/gerbv/gerbv/issues/36#issuecomment-954824283) the help dialog still points users to legacy websites

![139459593-eb990ab5-7bd6-4ef4-b589-f50138b6c7a5](https://user-images.githubusercontent.com/2611835/139484082-6003e79d-4929-4857-a25b-aad45284b070.png)

This patch updates the source code to reflect move to GitHub

![updated-help-dialog](https://user-images.githubusercontent.com/2611835/139484116-3a54f799-2b6a-423e-bc4b-e88a750ec9a1.png)

This fixes issue #37