### PR TITLE
Use -isystem for gtk include

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -392,11 +392,12 @@ AC_CHECK_FUNCS(strlwr)
 AC_CHECK_FUNCS(realpath canonicalize_file_name)
 libiberty_NEED_DECLARATION(canonicalize_file_name)
 
+AC_SUBST([GTK_CFLAGS_ISYSTEM], ['$(subst -I/usr/include/gtk-2.0,-isystem /usr/include/gtk-2.0,$(GTK_CFLAGS))'])
 
-CFLAGS="$CFLAGS $GDK_PIXBUF_CFLAGS $GTK_CFLAGS $CAIRO_CFLAGS"
+CFLAGS="$CFLAGS $GDK_PIXBUF_CFLAGS $GTK_CFLAGS_ISYSTEM $CAIRO_CFLAGS"
 LIBS="$LIBS $GDK_PIXBUF_LIBS $GTK_LIBS $CAIRO_LIBS -lm"
 
-CPPFLAGS="$CPPFLAGS $GTK_CFLAGS"
+CPPFLAGS="$CPPFLAGS $GTK_CFLAGS_ISYSTEM"
 
 ############################################################
 #


### PR DESCRIPTION
GTK has some warnings internally that we'd like to ignore.  This will
ignore warnings that are about code in GTK.  Warnings about code in
gerbv will not be suppressed.

This fixes #54 