### PR TITLE
Updates to the autotool related files due deprecation warnings within recent autotool calling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ SUBDIRS = \
 	share/glib-2.0/schemas \
 	desktop \
 	doc man \
-	intl po \
+	po \
 	example \
 	test \
 	win32

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -6,33 +6,41 @@ dnl From gcc's libiberty aclocal.m4
 
 dnl See whether we need a declaration for a function.
 AC_DEFUN([libiberty_NEED_DECLARATION],
-[AC_MSG_CHECKING([whether $1 must be declared])
-AC_CACHE_VAL(libiberty_cv_decl_needed_$1,
-[AC_TRY_COMPILE([
-#include "confdefs.h"
-#include <stdio.h>
-#ifdef HAVE_STRING_H
-#include <string.h>
-#else
-#ifdef HAVE_STRINGS_H
-#include <strings.h>
-#endif
-#endif
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif],
-[char *(*pfn) = (char *(*)) $1],
-libiberty_cv_decl_needed_$1=no, libiberty_cv_decl_needed_$1=yes)])
-AC_MSG_RESULT($libiberty_cv_decl_needed_$1)
-if test $libiberty_cv_decl_needed_$1 = yes; then
-	AC_DEFINE([NEED_DECLARATION_]translit($1, [a-z], [A-Z]), 1,
-	[Define if $1 is not declared in system header files.])
+[
+  AC_MSG_CHECKING([whether $1 must be declared])
+  AC_CACHE_VAL(libiberty_cv_decl_needed_$1,
+  [AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+dnl includes
+[[#include "confdefs.h"
+  #include <stdio.h>
+  #ifdef HAVE_STRING_H
+    #include <string.h>
+  #else
+    #ifdef HAVE_STRINGS_H
+      #include <strings.h>
+    #endif
+  #endif
+  #ifdef HAVE_STDLIB_H
+    #include <stdlib.h>
+  #endif
+  #ifdef HAVE_UNISTD_H
+    #include <unistd.h>
+  #endif]],
+dnl function(s) to check
+[[char *(*pfn) = (char *(*)) $1]]
+)],
+dnl check was successful
+[libiberty_cv_decl_needed_$1=no],
+dnl check was not successful
+[libiberty_cv_decl_needed_$1=yes]
+)]
+)
+  AC_MSG_RESULT([$libiberty_cv_decl_needed_$1])
+  if test $libiberty_cv_decl_needed_$1 = yes; then
+      AC_DEFINE([NEED_DECLARATION_]translit($1, [a-z], [A-Z]), 1,
+                [Define if $1 is not declared in system header files.])
 fi
-])dnl
-
+])
 
 dnl ----------------------------------------------------------------
 dnl From http://autoconf-archive.cryp.to/adl_compute_relative_paths.html

--- a/configure.ac
+++ b/configure.ac
@@ -24,20 +24,21 @@ dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 AC_INIT([gerbv], [m4_esyscmd(utils/git-version-gen.sh 2.8.1-dev)])
 AC_CONFIG_SRCDIR([src/gerbv.c])
-AC_PREREQ([2.59])
+AC_PREREQ([2.69])
 AM_INIT_AUTOMAKE([1.9])
-AC_GNU_SOURCE
+AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_MACRO_DIR([m4])
 
 dnl Create a configuration header 
-AM_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 dnl Initialize maintainer mode
 AM_MAINTAINER_MODE
 
 dnl Internationalisation
+dnl https://www.gnu.org/software/gettext/manual/html_node/AM_005fGNU_005fGETTEXT.html
 AM_NLS
-AM_GNU_GETTEXT
+AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19])
 #AX_DESKTOP_I18N
 
@@ -168,13 +169,12 @@ AM_SANITY_CHECK
 
 dnl Checks for programs.
 AC_PROG_CC
-AC_PROG_CC_C99
 if test "x$enable_dxf " != "xno" ; then
 AC_PROG_CXX
 fi
 AC_PROG_MAKE_SET
 AC_PROG_INSTALL
-AC_PROG_LIBTOOL
+LT_INIT
 
 if test "x$WIN32" = "xyes" ; then
 	AC_CHECK_TOOL(WINDRES, windres, no)
@@ -367,8 +367,7 @@ fi
 AC_SUBST(XDGDATADIR)
 
 AC_ARG_ENABLE(update-desktop-database,
-	AC_HELP_STRING([--disable-update-desktop-database],
-	[do not update desktop database after installation]),,
+	AS_HELP_STRING([--disable-update-desktop-database],[do not update desktop database after installation]),,
 	enable_update_desktop_database=yes)
 
 AM_CONDITIONAL(ENABLE_UPDATE_DESKTOP_DATABASE, test x$enable_update_desktop_database = xyes)
@@ -455,7 +454,7 @@ AC_DEFINE_UNQUOTED(BINDIR_TO_EXECPREFIX, "$bindir_to_execprefix", [Relative path
 #
 ############################################################
 
-AC_OUTPUT(	Makefile \
+AC_CONFIG_FILES([Makefile \
 		src/Makefile \
 		src/libgerbv.pc \
 		scheme/Makefile \
@@ -470,7 +469,6 @@ AC_OUTPUT(	Makefile \
 		doc/Makefile \
 		man/Makefile \
 		\
-		intl/Makefile \
 		po/Makefile.in \
 		\
 		example/eaglecad1/Makefile \
@@ -495,7 +493,8 @@ AC_OUTPUT(	Makefile \
 		test/inputs/Makefile \
 		\
 		win32/Makefile \
-		)
+		])
+AC_OUTPUT
         
 expandedXDGDATADIR=`eval "echo $XDGDATADIR"`
 


### PR DESCRIPTION
This PR is about needed updates to the typical used autotool files.

At least since Autotool 2.68 some deprecation's are emitted if the script `autogen.sh` is called to re-create the configuration script and additional related files.
The deprecation's are getting more by using Autotoconf 2.70.

The PR is adding the various suggestions to fix the emitted warnings by modifying the underlying M4 code within the *.ac and *.m4 files.