### PR TITLE
G00, G01 unsupported modes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,16 @@
 ========================================================================
+Release Notes for gerbv-2.7.2-rc.1
+========================================================================
+This is a minor patch release on top of gerbv-2.7.1 in order to fix the security
+vulnerability CVE-2021-40394 / TALOS-2021-1405 discovered by the Cisco Talos
+team.
+
+========================================================================
 Release Notes for gerbv-2.7.1
 ========================================================================
 This is a minor patch release on top of gerbv-2.7.0 in order to fix the security
-vulnerability TALOS-2021-1402 discovered by the Cisco Talos team.
+vulnerability CVE-2021-40391 / TALOS-2021-1402 discovered by the Cisco Talos
+team.
 
 ========================================================================
 Release Notes for gerbv-2.7.0

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,11 @@
 ========================================================================
+Release Notes for gerbv-2.7.3-rc.1
+========================================================================
+This is a minor patch release on top of gerbv-2.7.2 in order to fix the security
+vulnerability CVE-2021-40393 / TALOS-2021-1404 discovered by the Cisco Talos
+team.
+
+========================================================================
 Release Notes for gerbv-2.7.2
 ========================================================================
 This is a minor patch release on top of gerbv-2.7.1 in order to fix the security

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 ========================================================================
-Release Notes for gerbv-2.7.2-rc.1
+Release Notes for gerbv-2.7.2
 ========================================================================
 This is a minor patch release on top of gerbv-2.7.1 in order to fix the security
 vulnerability CVE-2021-40394 / TALOS-2021-1405 discovered by the Cisco Talos

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
 ========================================================================
+Release Notes for gerbv-2.7.1
+========================================================================
+This is a minor patch release on top of gerbv-2.7.0 in order to fix the security
+vulnerability TALOS-2021-1402 discovered by the Cisco Talos team.
+
+========================================================================
 Release Notes for gerbv-2.7.0
 ========================================================================
 -gerbv:     User interface settings are saved with GSettings (units,

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 ========================================================================
-Release Notes for gerbv-2.7.3-rc.1
+Release Notes for gerbv-2.7.3
 ========================================================================
 This is a minor patch release on top of gerbv-2.7.2 in order to fix the security
 vulnerability CVE-2021-40393 / TALOS-2021-1404 discovered by the Cisco Talos

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with this program; if not, write to the Free Software
 dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 
-AC_INIT([gerbv], [2.7.2-rc.1])
+AC_INIT([gerbv], [2.7.2])
 AC_CONFIG_SRCDIR([src/gerbv.c])
 AC_PREREQ([2.59])
 AM_INIT_AUTOMAKE([1.9])

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with this program; if not, write to the Free Software
 dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 
-AC_INIT([gerbv], [2.7.2])
+AC_INIT([gerbv], [2.7.3-rc.1])
 AC_CONFIG_SRCDIR([src/gerbv.c])
 AC_PREREQ([2.59])
 AM_INIT_AUTOMAKE([1.9])

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with this program; if not, write to the Free Software
 dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 
-AC_INIT([gerbv], [2.7.0])
+AC_INIT([gerbv], [2.7.1])
 AC_CONFIG_SRCDIR([src/gerbv.c])
 AC_PREREQ([2.59])
 AM_INIT_AUTOMAKE([1.9])

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with this program; if not, write to the Free Software
 dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 
-AC_INIT([gerbv], [2.7.3-rc.1])
+AC_INIT([gerbv], [2.7.3])
 AC_CONFIG_SRCDIR([src/gerbv.c])
 AC_PREREQ([2.59])
 AM_INIT_AUTOMAKE([1.9])

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl  along with this program; if not, write to the Free Software
 dnl  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
 
 
-AC_INIT([gerbv], [2.7.1])
+AC_INIT([gerbv], [2.7.2-rc.1])
 AC_CONFIG_SRCDIR([src/gerbv.c])
 AC_PREREQ([2.59])
 AM_INIT_AUTOMAKE([1.9])

--- a/src/drill.c
+++ b/src/drill.c
@@ -1115,6 +1115,7 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
 		_("Out of bounds drill number %d "
 		    "at line %ld in file \"%s\""),
 		tool_num, file_line, fd->filename);
+	return -1;
     }
 
     /* Set the current tool to the correct one */

--- a/src/gerber.c
+++ b/src/gerber.c
@@ -28,6 +28,7 @@
 
 #include "gerbv.h"
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
@@ -1936,14 +1937,22 @@ simplify_aperture_macro(gerbv_aperture_t *aperture, gdouble scale)
 	case GERBV_OPCODE_PUSH :
 	    push(s, ip->data.fval);
 	    break;
-        case GERBV_OPCODE_PPUSH :
-	    push(s, lp[ip->data.ival - 1]);
+        case GERBV_OPCODE_PPUSH : {
+	    ssize_t const idx = ip->data.ival - 1;
+	    if ((idx < 0) || (idx >= APERTURE_PARAMETERS_MAX))
+		GERB_FATAL_ERROR(_("Tried to access oob aperture"));
+	    push(s, lp[idx]);
 	    break;
-	case GERBV_OPCODE_PPOP:
+	}
+	case GERBV_OPCODE_PPOP: {
 	    if (pop(s, &tmp[0]) < 0)
 		GERB_FATAL_ERROR(_("Tried to pop an empty stack"));
-	    lp[ip->data.ival - 1] = tmp[0];
+	    ssize_t const idx = ip->data.ival - 1;
+	    if ((idx < 0) || (idx >= APERTURE_PARAMETERS_MAX))
+		GERB_FATAL_ERROR(_("Tried to access oob aperture"));
+	    lp[idx] = tmp[0];
 	    break;
+	}
 	case GERBV_OPCODE_ADD :
 	    if (pop(s, &tmp[0]) < 0)
 		GERB_FATAL_ERROR(_("Tried to pop an empty stack"));


### PR DESCRIPTION
I'm using gerbv just for inspection of finished PCBs in order to find minor errors before manufacturing them but, as you know, there are unsupported G modes which are affecting my PCBs when I use non-standard drills (e.g. oblong holes).

In spite of I'm not use to program in this enviroment, I made some minor modifications in order to:
1) get a real line counter (thru a new global variable f_line in drill and new functions to read characters from files (*))
2) draw oblongs ("oval" type holes) on the screen (as I just need it for a visual inspection, for now it's not important to export or print them)

The three files affected are:
- gerbv.h
- drill.c
- draw-gdk.c
[mods.zip](https://github.com/gerbv/gerbv/files/7698682/mods.zip)

Hope it helps.

P.S. Usually I run gerbv in a Linux computer but as sometimes I need to use it in an old Windows laptop, it would be wonderful if you may add a Win32 version to the "Release" files, I have been trying to cross-compiling for Win32 but I haven't managed to make it work yet.

(*) For now just for debug but the patch fixed the faulty line counter without modifications to the main code. 