### PR TITLE
Linux packaging: pass command line arguments from gerbv.sh

### DIFF
--- a/.mc/package-linux.sh
+++ b/.mc/package-linux.sh
@@ -94,7 +94,7 @@ TEMPORARY_DIRECTORY=`"${MKTEMP}" --directory`
 #!/bin/bash
 
 DIRECTORY=\`dirname "\$0"\`
-LD_LIBRARY_PATH="\${LD_LIBRARY_PATH}:\${DIRECTORY}" "\${DIRECTORY}/gerbv"
+LD_LIBRARY_PATH="\${LD_LIBRARY_PATH}:\${DIRECTORY}" "\${DIRECTORY}/gerbv" "\$@"
 EOT
 
 "${CHMOD}" +x "${TEMPORARY_DIRECTORY}/gerbv.sh"


### PR DESCRIPTION
Gerbv has a nice command line interface.
This commit allows using it through the gerbv.sh wrapper script also.