### PR TITLE
Include init.scm in releases

### DIFF
--- a/.mc/package-linux.sh
+++ b/.mc/package-linux.sh
@@ -87,6 +87,7 @@ WEBSITE_DIRECTORY='gerbv.github.io/ci'
 TEMPORARY_DIRECTORY=`"${MKTEMP}" --directory`
 
 "${CP}" 'COPYING' "${TEMPORARY_DIRECTORY}"
+"${CP}" 'src/init.scm' "${TEMPORARY_DIRECTORY}"
 "${CP}" 'src/.libs/gerbv' "${TEMPORARY_DIRECTORY}"
 "${FIND}" 'src/.libs' -name 'libgerbv.so*' -exec "${CP}" {} "${TEMPORARY_DIRECTORY}" \;
 

--- a/.mc/windows:amd64/opt/package.sh
+++ b/.mc/windows:amd64/opt/package.sh
@@ -66,6 +66,7 @@ WEBSITE_DIRECTORY='gerbv.github.io/ci'
 TEMPORARY_DIRECTORY=`"${MKTEMP}" --directory`
 
 "${CP}" 'COPYING' "${TEMPORARY_DIRECTORY}"
+"${CP}" 'src/init.scm' "${TEMPORARY_DIRECTORY}"
 "${CP}" 'src/.libs/gerbv.exe' "${TEMPORARY_DIRECTORY}"
 "${FIND}" 'src/.libs' -name 'libgerbv-*.dll' -exec "${CP}" {} "${TEMPORARY_DIRECTORY}" \;
 


### PR DESCRIPTION
Gerbv cannot open project files without `init.scm`.

Fixes issue #111