### PR TITLE
Use latest Fedora release for Windows cross compilation

### DIFF
--- a/.mc/windows:amd64/windows:amd64.yaml
+++ b/.mc/windows:amd64/windows:amd64.yaml
@@ -1,5 +1,5 @@
 ---
-base: fedora:35
+base: fedora:36
 install:
  - make
  - mingw64-gcc


### PR DESCRIPTION
Should have no impact on created binary but avoids getting stuck on an unsupported Fedora release on CI.

Resulting binary was smoke tested using wine.