### PR TITLE
Improve const correctness

### DIFF
--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -222,14 +222,14 @@ gerbv_destroy_fileinfo (gerbv_fileinfo_t *fileInfo){
 
 /* ------------------------------------------------------------------ */
 void 
-gerbv_open_layer_from_filename(gerbv_project_t *gerbvProject, gchar *filename) 
+gerbv_open_layer_from_filename(gerbv_project_t *gerbvProject, gchar const* filename)
 {
   gint idx_loaded;
-  dprintf("Opening filename = %s\n", (gchar *) filename);
+  dprintf("Opening filename = %s\n", filename);
   
   if (gerbv_open_image(gerbvProject, filename, ++gerbvProject->last_loaded, FALSE, NULL, 0, TRUE) == -1) {
     GERB_COMPILE_WARNING(_("Could not read \"%s\" (loaded %d)"),
-		    (gchar *) filename, gerbvProject->last_loaded);
+		    filename, gerbvProject->last_loaded);
     gerbvProject->last_loaded--;
   } else {
     idx_loaded = gerbvProject->last_loaded;
@@ -240,15 +240,15 @@ gerbv_open_layer_from_filename(gerbv_project_t *gerbvProject, gchar *filename)
 
 /* ------------------------------------------------------------------ */
 void 
-gerbv_open_layer_from_filename_with_color(gerbv_project_t *gerbvProject, gchar *filename,
+gerbv_open_layer_from_filename_with_color(gerbv_project_t *gerbvProject, gchar const* filename,
 		guint16 red, guint16 green, guint16 blue, guint16 alpha)
 {
   gint idx_loaded;
-  dprintf("Opening filename = %s\n", (gchar *) filename);
+  dprintf("Opening filename = %s\n", filename);
   
   if (gerbv_open_image(gerbvProject, filename, ++gerbvProject->last_loaded, FALSE, NULL, 0, TRUE) == -1) {
     GERB_COMPILE_WARNING(_("Could not read \"%s\" (loaded %d)"),
-		    (gchar *) filename, gerbvProject->last_loaded);
+		    filename, gerbvProject->last_loaded);
     gerbvProject->last_loaded--;
   } else {
     idx_loaded = gerbvProject->last_loaded;
@@ -394,7 +394,7 @@ gerbv_change_layer_order(gerbv_project_t *gerbvProject, gint oldPosition, gint n
 /* ------------------------------------------------------------------ */
 gint
 gerbv_add_parsed_image_to_project (gerbv_project_t *gerbvProject, gerbv_image_t *parsed_image,
-			gchar *filename, gchar *baseName, int idx, int reload){
+			gchar const* filename, gchar const* baseName, int idx, int reload){
     gerb_verify_error_t error = GERB_IMAGE_OK;
     int r, g, b; 
     
@@ -461,7 +461,7 @@ gerbv_add_parsed_image_to_project (gerbv_project_t *gerbvProject, gerbv_image_t 
 
 /* ------------------------------------------------------------------ */
 int
-gerbv_open_image(gerbv_project_t *gerbvProject, char *filename, int idx, int reload,
+gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, int reload,
 		gerbv_HID_Attribute *fattr, int n_fattr, gboolean forceLoadFile)
 {
     gerb_file_t *fd;
@@ -616,7 +616,7 @@ gerbv_open_image(gerbv_project_t *gerbvProject, char *filename, int idx, int rel
 } /* open_image */
 
 gerbv_image_t *
-gerbv_create_rs274x_image_from_filename (gchar *filename){
+gerbv_create_rs274x_image_from_filename (gchar const* filename){
 	gerbv_image_t *returnImage;
 	gerb_file_t *fd;
 	

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -820,13 +820,13 @@ gerbv_destroy_project (gerbv_project_t *gerbvProject /*!< the project to destroy
 void 
 gerbv_open_layer_from_filename (
 	gerbv_project_t *gerbvProject, /*!< the existing project to add the new layer to */
-	gchar *filename /*!< the full pathname of the file to be parsed */
+	gchar const* filename /*!< the full pathname of the file to be parsed */
 );
 
 //! Open a file, parse the contents, and add a new layer to an existing project while setting the color of the layer
 void 
 gerbv_open_layer_from_filename_with_color(gerbv_project_t *gerbvProject, /*!< the existing project to add the new layer to */
-	gchar *filename, /*!< the full pathname of the file to be parsed */
+	gchar const* filename, /*!< the full pathname of the file to be parsed */
 	guint16 red, /*!< the value for the red color component */
 	guint16 green, /*!< the value for the green color component */
 	guint16 blue, /*!< the value for the blue color component */
@@ -858,9 +858,9 @@ gerbv_change_layer_order(gerbv_project_t *gerbvProject, gint oldPosition, gint n
 
 gint
 gerbv_add_parsed_image_to_project (gerbv_project_t *gerbvProject, gerbv_image_t *parsed_image,
-			gchar *filename, gchar *baseName, int idx, int reload);
+			gchar const* filename, gchar const* baseName, int idx, int reload);
 int
-gerbv_open_image(gerbv_project_t *gerbvProject, char *filename, int idx, int reload,
+gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, int reload,
 		gerbv_HID_Attribute *fattr, int n_fattr, gboolean forceLoadFile);
 		
 void
@@ -984,7 +984,7 @@ gerbv_export_dxf_file_from_image (const gchar *filename, /*!< the filename for t
 //! Parse a RS274X file and return the parsed image
 //! \return the new gerbv_image_t, or NULL if not successful
 gerbv_image_t *
-gerbv_create_rs274x_image_from_filename (gchar *filename /*!< the filename of the file to be parsed*/
+gerbv_create_rs274x_image_from_filename (const gchar *filename /*!< the filename of the file to be parsed*/
 );
 
 //! Export an image to a new file in RS274X format


### PR DESCRIPTION
When using libgerbv from C++ usability can be improved by marking effective const variables as `const`