### PR TITLE
RFC: How to patch CVE-2021-40402

### DIFF
--- a/src/gerb_safety.h
+++ b/src/gerb_safety.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#ifndef GERBV_GERBV_SAFETY
+#define GERBV_GERBV_SAFETY
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "gerbv.h"
+
+inline size_t gerbv_simplified_amacro_parameter_idx(gerbv_simplified_amacro_t const* amacro, size_t idx) {
+    static_assert(
+        (sizeof(amacro->parameter) / sizeof(amacro->parameter[0])) == APERTURE_PARAMETERS_MAX,
+        "Statically known gerbv_simplified_amacro parameter array size has changed");
+
+    if (idx < APERTURE_PARAMETERS_MAX) {
+        return idx;
+    }
+
+    GERB_FATAL_ERROR(/*_*/("invalid gerbv_simplified_amacro parameter index"));
+    return 0;
+}
+
+#define gerbv_simplified_amacro_parameter(gerbv_simplified_amacro, idx)	\
+	((gerbv_simplified_amacro)->parameter[gerbv_simplified_amacro_parameter_idx((gerbv_simplified_amacro), (idx))])
+
+
+#endif
+

--- a/src/gerber.c
+++ b/src/gerber.c
@@ -39,6 +39,7 @@
 #include "common.h"
 #include "gerb_image.h"
 #include "gerber.h"
+#include "gerb_safety.h"
 #include "gerb_stats.h"
 #include "amacro.h"
 
@@ -1925,6 +1926,8 @@ simplify_aperture_macro(gerbv_aperture_t *aperture, gdouble scale)
     gerbv_aperture_type_t type = GERBV_APTYPE_NONE;
     gerbv_simplified_amacro_t *sam;
 
+    #define SAM_PARAMETER(idx) gerbv_simplified_amacro_parameter(sam, (idx))
+
     if (aperture == NULL)
 	GERB_FATAL_ERROR(_("aperture NULL in simplify aperture macro"));
 
@@ -2098,59 +2101,59 @@ simplify_aperture_macro(gerbv_aperture_t *aperture, gdouble scale)
 		/* convert any mm values to inches */
 		switch (type) {
 		    case GERBV_APTYPE_MACRO_CIRCLE:
-			if (fabs(sam->parameter[0]) < 0.001)
+			if (fabs(SAM_PARAMETER(0)) < 0.001)
 			    clearOperatorUsed = TRUE;
-			sam->parameter[1]/=scale;
-			sam->parameter[2]/=scale;
-			sam->parameter[3]/=scale;
+			SAM_PARAMETER(1)/=scale;
+			SAM_PARAMETER(2)/=scale;
+			SAM_PARAMETER(3)/=scale;
 			break;
 		    case GERBV_APTYPE_MACRO_OUTLINE:
-			if (fabs(sam->parameter[0]) < 0.001)
+			if (fabs(SAM_PARAMETER(0)) < 0.001)
 			    clearOperatorUsed = TRUE;
 			for (j=2; j<nuf_parameters-1; j++){
-			    sam->parameter[j]/=scale;
+			    SAM_PARAMETER(j)/=scale;
 			}
 			break;
 		    case GERBV_APTYPE_MACRO_POLYGON:
-			if (fabs(sam->parameter[0]) < 0.001)
+			if (fabs(SAM_PARAMETER(0)) < 0.001)
 			    clearOperatorUsed = TRUE;
-			sam->parameter[2]/=scale;
-			sam->parameter[3]/=scale;
-			sam->parameter[4]/=scale;
+			SAM_PARAMETER(2)/=scale;
+			SAM_PARAMETER(3)/=scale;
+			SAM_PARAMETER(4)/=scale;
 			break;
 		    case GERBV_APTYPE_MACRO_MOIRE:
-			sam->parameter[0]/=scale;
-			sam->parameter[1]/=scale;
-			sam->parameter[2]/=scale;
-			sam->parameter[3]/=scale;
-			sam->parameter[4]/=scale;
-			sam->parameter[6]/=scale;
-			sam->parameter[7]/=scale;
+			SAM_PARAMETER(0)/=scale;
+			SAM_PARAMETER(1)/=scale;
+			SAM_PARAMETER(2)/=scale;
+			SAM_PARAMETER(3)/=scale;
+			SAM_PARAMETER(4)/=scale;
+			SAM_PARAMETER(6)/=scale;
+			SAM_PARAMETER(7)/=scale;
 			break;
 		    case GERBV_APTYPE_MACRO_THERMAL:
-			sam->parameter[0]/=scale;
-			sam->parameter[1]/=scale;
-			sam->parameter[2]/=scale;
-			sam->parameter[3]/=scale;
-			sam->parameter[4]/=scale;
+			SAM_PARAMETER(0)/=scale;
+			SAM_PARAMETER(1)/=scale;
+			SAM_PARAMETER(2)/=scale;
+			SAM_PARAMETER(3)/=scale;
+			SAM_PARAMETER(4)/=scale;
 			break;
 		    case GERBV_APTYPE_MACRO_LINE20:
-			if (fabs(sam->parameter[0]) < 0.001)
+			if (fabs(SAM_PARAMETER(0)) < 0.001)
 			    clearOperatorUsed = TRUE;
-			sam->parameter[1]/=scale;
-			sam->parameter[2]/=scale;
-			sam->parameter[3]/=scale;
-			sam->parameter[4]/=scale;
-			sam->parameter[5]/=scale;
+			SAM_PARAMETER(1)/=scale;
+			SAM_PARAMETER(2)/=scale;
+			SAM_PARAMETER(3)/=scale;
+			SAM_PARAMETER(4)/=scale;
+			SAM_PARAMETER(5)/=scale;
 			break;
 		    case GERBV_APTYPE_MACRO_LINE21:
 		    case GERBV_APTYPE_MACRO_LINE22:
-			if (fabs(sam->parameter[0]) < 0.001)
+			if (fabs(SAM_PARAMETER(0)) < 0.001)
 			    clearOperatorUsed = TRUE;
-			sam->parameter[1]/=scale;
-			sam->parameter[2]/=scale;
-			sam->parameter[3]/=scale;
-			sam->parameter[4]/=scale;
+			SAM_PARAMETER(1)/=scale;
+			SAM_PARAMETER(2)/=scale;
+			SAM_PARAMETER(3)/=scale;
+			SAM_PARAMETER(4)/=scale;
 			break;
 		    default: 
 			break;			
@@ -2198,6 +2201,8 @@ simplify_aperture_macro(gerbv_aperture_t *aperture, gdouble scale)
        primatives */
     aperture->parameter[0]= (gdouble) clearOperatorUsed;
     return handled;
+
+    #undef SAM_PARAMETER
 } /* simplify_aperture_macro */
 
 


### PR DESCRIPTION
Issue #80 has identified multiple out of bound accesses regarding [gerbv_simplified_amacro_t::parameter](https://github.com/gerbv/gerbv/blob/main/src/gerbv.h#L422).

I have banged my head against this problem for a couple of days, but could not find a good way without playing wack a mole. At least `gerbv_simplified_amacro_t::parameter` and `gerbv_aperture_t::parameter` are vulnerable and accessed throughout the program.

Three ways of accessing these arrays have been identified:

* `val = sam->parameter[idx]`: No problem here, access could be replaced by a simple inline function doing bounds checking
* `sam->parameter[idx] += val`: Cannot be replaced with an inline function, unless returning a pointer and doing `*sam_parameter(sam, idx) += val`. Decided against returning a pointer and instead using a macro
* `*double val = sam_parameter + idx`: Could be replaced with an inline function returning a pointer, as well

@eyal0 / @spe-ciellt: Do you have input on how to patch this vulnerability? I would prefer replacing all access sites at once instead of trying manual index validation where necessary.