### PR TITLE
Update BUGS file to point to issue tracker

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,11 +1,2 @@
-Currently KNOWN BUGS
-
-All OS:
-
-If layer orientation modified with rotation and rendering mode is 'Fast' or
-'Fast, with XOR' (GDK rendering) line22 macro apertures are not rotated
-and not correctly displayed.
-
-Reporting about macro parameters (obtained via analyze -> analyze visible
-Gerber layers, and found in the Aperture definitions tab) incorrectly
-reports the macro parameters found.
+Currently KNOWN BUGS are tracked on the gerbv bug tracker at
+https://github.com/gerbv/gerbv/issues


### PR DESCRIPTION
The BUGS file was no longer kept up to date since half a decade ago. Therefore it's more user friendly to point to the issue tracker.

I have not updated the translation files. Will fix #129 