### PR TITLE
fix: Free the memory allocated in aperture macro comments.

### DIFF
--- a/example/am-test/am-test.gbx
+++ b/example/am-test/am-test.gbx
@@ -5,6 +5,7 @@ G04 Handcoded by Stefan Petersen *
 %OFA0.0000B0.0000*%
 G90*
 %AMCIRCLE*
+0 I am a comment in an aperture macro*
 1,1,$1,0,0*
 %
 %AMVECTOR*

--- a/src/amacro.c
+++ b/src/amacro.c
@@ -254,7 +254,7 @@ parse_aperture_macro(gerb_file_t *fd)
 	     */
 	    if (!found_primitive && (primitive == 0)) {
 		/* Comment continues 'til next *, just throw it away */
-		gerb_fgetstring(fd, '*');
+		free(gerb_fgetstring(fd, '*'));
 		c = gerb_fgetc(fd); /* Read the '*' */
 		break;
 	    }

--- a/test/run_valgrind_tests.sh
+++ b/test/run_valgrind_tests.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-./run_tests.sh --valgrind example_cslk out-of-bounds-drill-tool
+./run_tests.sh --valgrind \
+               example_cslk \
+               out-of-bounds-drill-tool \
+               example_am_test


### PR DESCRIPTION
The return of `gerb_fgetstring` must be freed even though it is not used.  `gerb_fgetstring` may return NULL but `free(NULL)` is allowed and does nothing.

A comment is added into an aperture macro of one of the test files. That file is added to the list of examples to be run with valgrind.