### PR TITLE
Unify include guards

### DIFF
--- a/src/amacro.h
+++ b/src/amacro.h
@@ -26,8 +26,8 @@
     \ingroup libgerbv
 */
 
-#ifndef AMACRO_H
-#define AMACRO_H
+#ifndef GERBV_AMACRO_H
+#define GERBV_AMACRO_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,4 +53,4 @@ void print_program(gerbv_amacro_t *amacro);
 }
 #endif
 
-#endif /* AMACRO_H */
+#endif /* GERBV_AMACRO_H */

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -28,8 +28,8 @@
     \ingroup gerbv
 */
 
-#ifndef ATTRIBUTE_H
-#define ATTRIBUTE_H
+#ifndef GERBV_ATTRIBUTE_H
+#define GERBV_ATTRIBUTE_H
 
 #include "gerbv.h"
 #ifdef __cplusplus
@@ -47,4 +47,4 @@ attribute_merge (gerbv_HID_Attribute *, int, gerbv_HID_Attribute *, int);
 }
 #endif
 
-#endif /*  ATTRIBUTE_H */
+#endif /* GERBV_ATTRIBUTE_H */

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -26,6 +26,9 @@
     \ingroup gerbv
 */
 
+#ifndef GERBV_CALLBACKS_H
+#define GERBV_CALLBACKS_H
+
 typedef enum {
 	CALLBACKS_SAVE_PROJECT_AS,
 	CALLBACKS_SAVE_FILE_PS,
@@ -306,3 +309,4 @@ callbacks_create_window_surface (GtkWidget *widget);
 
 void utf8_snprintf(gchar *dst, gsize byte_len, const gchar *fmt, ...);
 
+#endif /*  GERBV_CALLBACKS_H */

--- a/src/common.h
+++ b/src/common.h
@@ -25,8 +25,8 @@
     \ingroup libgerbv
 */
 
-#ifndef __COMMON_H__
-#define __COMMON_H__
+#ifndef GERBV_COMMON_H
+#define GERBV_COMMON_H
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -51,5 +51,5 @@
 # define N_(str) (str)
 #endif
 
-#endif /* __COMMON_H__ */
+#endif /* GERBV_COMMON_H */
 

--- a/src/csv.h
+++ b/src/csv.h
@@ -35,8 +35,8 @@
     \ingroup libgerbv
 */
 
-#ifndef CSV_H
-#define CSV_H
+#ifndef GERBV_CSV_H
+#define GERBV_CSV_H
 
 /* csv - read write comma separated value format
  */
@@ -67,4 +67,4 @@ LIBMBA_API int csv_row_fread(FILE *in, char *buf, size_t bn, char *row[], int nu
 }
 #endif
 
-#endif /* CSV_H */
+#endif /* GERBV_CSV_H */

--- a/src/csv_defines.h
+++ b/src/csv_defines.h
@@ -1,5 +1,5 @@
-#ifndef DEFINES_H
-#define DEFINES_H
+#ifndef GERBV_CSV_DEFINES_H
+#define GERBV_CSV_DEFINES_H
 /** 	\file csv_defines.h
 	\brief Sets up internal definitions for handling csv-style files
 	\ingroup libgerbv
@@ -60,4 +60,4 @@
 #define UNUSED
 #endif
 
-#endif /* DEFINES_H */
+#endif /* GERBV_CSV_DEFINES_H */

--- a/src/draw-gdk.h
+++ b/src/draw-gdk.h
@@ -26,8 +26,8 @@
     \ingroup libgerbv
 */
 
-#ifndef DRAW_GDK_H
-#define DRAW_GDK_H
+#ifndef GERBV_DRAW_GDK_H
+#define GERBV_DRAW_GDK_H
 
 #include <gdk/gdk.h>
 
@@ -44,5 +44,5 @@ int draw_gdk_image_to_pixmap(GdkPixmap **pixmap, gerbv_image_t *image,
 		gerbv_render_info_t *renderInfo,
 		gerbv_user_transformation_t transform);
 
-#endif /* DRAW_GDK_H */
+#endif /* GERBV_DRAW_GDK_H */
 

--- a/src/draw.h
+++ b/src/draw.h
@@ -36,9 +36,6 @@
 #include <cairo-svg.h>
 #include <cairo-pdf.h>
 
-#endif /* DRAW_H */
-
-
 /*
  * Convert a gerber image to a GDK clip mask to be used when creating pixmap
  */
@@ -49,3 +46,4 @@ draw_image_to_cairo_target (cairo_t *cairoTarget, gerbv_image_t *image,
 		gerbv_render_info_t *renderInfo, gboolean allowOptimization,
 		gerbv_user_transformation_t transform, gboolean pixelOutput);
 
+#endif /* DRAW_H */

--- a/src/draw.h
+++ b/src/draw.h
@@ -27,8 +27,8 @@
     \ingroup gerbv
 */
 
-#ifndef DRAW_H
-#define DRAW_H
+#ifndef GERBV_DRAW_H
+#define GERBV_DRAW_H
 
 #include <gdk/gdk.h>
 #include <cairo.h>
@@ -46,4 +46,4 @@ draw_image_to_cairo_target (cairo_t *cairoTarget, gerbv_image_t *image,
 		gerbv_render_info_t *renderInfo, gboolean allowOptimization,
 		gerbv_user_transformation_t transform, gboolean pixelOutput);
 
-#endif /* DRAW_H */
+#endif /* GERBV_DRAW_H */

--- a/src/drill.h
+++ b/src/drill.h
@@ -25,8 +25,8 @@
     \ingroup libgerbv
 */
 
-#ifndef DRILL_H
-#define DRILL_H
+#ifndef GERBV_DRILL_H
+#define GERBV_DRILL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -146,4 +146,4 @@ const char *drill_m_code_name(drill_m_code_t m_code);
 }
 #endif
 
-#endif /* DRILL_H */
+#endif /* GERBV_DRILL_H */

--- a/src/drill_stats.h
+++ b/src/drill_stats.h
@@ -26,8 +26,8 @@
     \ingroup libgerbv
 */
 
-#ifndef DRILL_STATS_H
-#define DRILL_STATS_H
+#ifndef GERBV_DRILL_STATS_H
+#define GERBV_DRILL_STATS_H
 
 #include <gdk/gdk.h>      /* This imports gboolean type */
 
@@ -52,4 +52,4 @@ void drill_stats_add_error(gerbv_error_list_t *error_list_in,
 			   int layer, const char *error_text, 
 			   gerbv_message_type_t type);
 
-#endif /* DRILL_STATS_H */
+#endif /* GERBV_DRILL_STATS_H */

--- a/src/dynload.h
+++ b/src/dynload.h
@@ -7,11 +7,11 @@
     \ingroup gerbv
 */
 
-#ifndef DYNLOAD_H
-#define DYNLOAD_H
+#ifndef GERBV_DYNLOAD_H
+#define GERBV_DYNLOAD_H
 
 #include "scheme-private.h"
 
 SCHEME_EXPORT pointer scm_load_ext(scheme *sc, pointer arglist);
 
-#endif
+#endif /* GERBV_DYNLOAD_H */

--- a/src/gerb_file.h
+++ b/src/gerb_file.h
@@ -26,8 +26,8 @@
     \ingroup libgerbv
 */
 
-#ifndef GERB_FILE_H
-#define GERB_FILE_H
+#ifndef GERBV_GERB_FILE_H
+#define GERBV_GERB_FILE_H
 
 #include <stdio.h>
 
@@ -57,4 +57,4 @@ void gerb_fclose(gerb_file_t *fd);
  */
 char *gerb_find_file(char const * filename, char **paths);
 
-#endif /* GERB_FILE_H */
+#endif /* GERBV_GERB_FILE_H */

--- a/src/gerb_image.h
+++ b/src/gerb_image.h
@@ -26,8 +26,8 @@
     \ingroup libgerbv
 */
 
-#ifndef GERB_IMAGE_H
-#define GERB_IMAGE_H
+#ifndef GERBV_GERB_IMAGE_H
+#define GERBV_GERB_IMAGE_H
 
 #include "gerb_stats.h"
 #include "drill_stats.h"
@@ -74,4 +74,4 @@ gerbv_image_return_new_netstate (gerbv_netstate_t *previousState);
 }
 #endif
 
-#endif /* GERB_IMAGE_H */
+#endif /* GERBV_GERB_IMAGE_H */

--- a/src/gerb_stats.h
+++ b/src/gerb_stats.h
@@ -26,8 +26,8 @@
     \ingroup libgerbv
 */
 
-#ifndef gerb_stats_H
-#define gerb_stats_H
+#ifndef GERBV_GERB_STATS_H
+#define GERBV_GERB_STATS_H
 
 
 
@@ -54,4 +54,4 @@ int gerbv_stats_increment_D_list_count(gerbv_aperture_list_t *D_list_in,
 				       int count,
 				       gerbv_error_list_t *error); 
 
-#endif /* gerb_stats_H */
+#endif /* GERBV_GERB_STATS_H */

--- a/src/gerber.h
+++ b/src/gerber.h
@@ -26,8 +26,8 @@
     \ingroup libgerbv
 */
 
-#ifndef GERBER_H
-#define GERBER_H
+#ifndef GERBV_GERBER_H
+#define GERBV_GERBER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,4 +83,4 @@ const char *gerber_m_code_name(int m_code);
 }
 #endif
 
-#endif /* GERBER_H */
+#endif /* GERBV_GERBER_H */

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -62,8 +62,8 @@ For help with using the standalone Gerbv software, please refer to the man page
 
 */
 
-#ifndef __GERBV_H__
-#define __GERBV_H__
+#ifndef GERBV_GERBV_H
+#define GERBV_GERBV_H
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"
@@ -1130,4 +1130,4 @@ gerbv_rotate_coord(double *x, double *y, double rad);
 }
 #endif
 
-#endif /* __GERBV_H__ */
+#endif /* GERBV_GERBV_H */

--- a/src/interface.h
+++ b/src/interface.h
@@ -26,6 +26,9 @@
     \ingroup gerbv
 */
 
+#ifndef GERBV_INTERFACE_H
+#define GERBV_INTERFACE_H
+
 /** Sets the key acceleration of a menu item.
 First tries to lookup the given STOCK_ID with gtk_stock_lookup.
 If this succeeds and the retrieved GtkStockItem has an accelerator defined this accelerator is used.
@@ -213,3 +216,5 @@ interface_show_alert_dialog (gchar *primaryText,
 void
 interface_show_layer_edit_dialog (gerbv_user_transformation_t *transforms[],
 				  gerbv_unit_t screenUnit);
+
+#endif /* GERBV_INTERFACE_H */

--- a/src/lrealpath.h
+++ b/src/lrealpath.h
@@ -1,9 +1,9 @@
-#ifndef __LREALPATH_H__
-#define __LREALPATH_H__
+#ifndef GERBV_LREALPATH_H
+#define GERBV_LREALPATH_H
 
 /* A well-defined realpath () that is always compiled in.  */
 char *lrealpath (const char *);
 
-#endif /* __LREALPATH_H__ */
+#endif /* GERBV_LREALPATH_H */
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -26,8 +26,8 @@
     \ingroup gerbv
 */
 
-#ifndef MAIN_H
-#define MAIN_H
+#ifndef GERBV_MAIN_H
+#define GERBV_MAIN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -145,5 +145,5 @@ main_save_project_from_filename(gerbv_project_t *gerbvProject, gchar *filename);
 
 void
 main_open_project_from_filename(gerbv_project_t *gerbvProject, gchar *filename);
-#endif /* GERBV_H */
 
+#endif /* GERBV_MAIN_H */

--- a/src/opdefines.h
+++ b/src/opdefines.h
@@ -3,6 +3,9 @@
     \ingroup gerbv
 */
 
+#ifndef GERBV_OPDEFINES_H
+#define GERBV_OPDEFINES_H
+
     _OP_DEF(opexe_0, "load",                           1,  1,       TST_STRING,                      OP_LOAD             )
     _OP_DEF(opexe_0, 0,                                0,  0,       0,                               OP_T0LVL            )
     _OP_DEF(opexe_0, 0,                                0,  0,       0,                               OP_T1LVL            )
@@ -194,3 +197,5 @@
     _OP_DEF(opexe_6, "closure?",                       1,  1,       TST_NONE,                        OP_CLOSUREP         )
     _OP_DEF(opexe_6, "macro?",                         1,  1,       TST_NONE,                        OP_MACROP           )
 #undef _OP_DEF
+
+#endif /* GERBV_OPDEFINES_H */

--- a/src/project.h
+++ b/src/project.h
@@ -27,8 +27,8 @@
     \ingroup gerbv
  */ 
 
-#ifndef PROJECT_H
-#define PROJECT_H
+#ifndef GERBV_PROJECT_H
+#define GERBV_PROJECT_H
 
 typedef struct project_list_t {
     int layerno;
@@ -70,4 +70,5 @@ int write_project_file(gerbv_project_t *gerbvProject, char const* filename, proj
 
 void
 project_destroy_project_list (project_list_t *projectList);
-#endif /* PROJECT_H */
+
+#endif /* GERBV_PROJECT_H */

--- a/src/render.h
+++ b/src/render.h
@@ -27,6 +27,9 @@
     \ingroup gerbv
 */
 
+#ifndef GERBV_RENDER_H
+#define GERBV_RENDER_H
+
 #include "gerber.h"
 
 gerbv_stats_t *generate_gerber_analysis(void);
@@ -78,3 +81,4 @@ void render_fill_selection_buffer_from_mouse_drag (gint corner1X, gint corner1Y,
 
 extern gerbv_render_info_t screenRenderInfo;
 
+#endif /* GERBV_RENDER_H */

--- a/src/scheme-private.h
+++ b/src/scheme-private.h
@@ -5,8 +5,8 @@
     \ingroup gerbv
 */
 
-#ifndef _SCHEME_PRIVATE_H
-#define _SCHEME_PRIVATE_H
+#ifndef GERBV_SCHEME_PRIVATE_H
+#define GERBV_SCHEME_PRIVATE_H
 
 #include "scheme.h"
 
@@ -186,4 +186,4 @@ int is_environment(pointer p);
 int is_immutable(pointer p);
 void setimmutable(pointer p);
 
-#endif
+#endif /* GERBV_SCHEME_PRIVATE_H */

--- a/src/scheme.h
+++ b/src/scheme.h
@@ -5,8 +5,8 @@
     \ingroup gerbv
 */
 
-#ifndef _SCHEME_H
-#define _SCHEME_H
+#ifndef GERBV_SCHEME_H
+#define GERBV_SCHEME_H
 
 #include <stdio.h>
 
@@ -225,5 +225,5 @@ struct scheme_interface {
 };
 #endif
 
-#endif
+#endif /* GERBV_SCHEME_H */
 

--- a/src/selection.h
+++ b/src/selection.h
@@ -25,6 +25,9 @@
     \ingroup libgerbv
 */
 
+#ifndef GERBV_SELECTION_H
+#define GERBV_SELECTION_H
+
 GArray *selection_new_array (void);
 guint selection_length (gerbv_selection_info_t *sel_info);
 void selection_add_item (gerbv_selection_info_t *sel_info,
@@ -35,3 +38,4 @@ void selection_clear_item_by_index (
 				gerbv_selection_info_t *sel_info, guint idx);
 void selection_clear (gerbv_selection_info_t *sel_info);
 
+#endif /* GERBV_SELECTION_H */

--- a/src/table.h
+++ b/src/table.h
@@ -3,8 +3,8 @@
     \ingroup gerbv
  */ 
 
-#ifndef TABLE_H
-#define TABLE_H
+#ifndef GERBV_TABLE_H
+#define GERBV_TABLE_H
 
 struct table {
 	GtkWidget	*widget;	/* All table */
@@ -20,4 +20,4 @@ void table_set_sortable(struct table *table);
 void table_set_column_align(struct table *table, gint column_num, gfloat align);
 int table_add_row(struct table *table, ...);
 
-#endif	/* TABLE_H */
+#endif	/* GERBV_TABLE_H */


### PR DESCRIPTION
All non vendored headers now use unified prefixed include guards.

See [issue #26](https://github.com/gerbv/gerbv/issues/26) for motivation and discussion.