### PR TITLE
ci: Upgrade checkout to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     name: ci${{ matrix.coverage }} # Coverage build has "-coverage" added to the name.
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get number of jobs for compiling
       run: echo "NUM_BUILD_JOBS=$((`nproc --all` * 4))" >> $GITHUB_ENV


### PR DESCRIPTION
This fixes a warning about the old node version.

https://github.com/actions/checkout#whats-new