### PR TITLE
ci: Update github-pages-deploy-action to 4.4.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
         find gerbv.github.io -type f -name '.gitignore' -exec rm {} \;
 
     - name: Deploy gerbv.github.io
-      uses: JamesIves/github-pages-deploy-action@v4.3.3
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:
         repository-name: gerbv/gerbv.github.io
         branch: gh-pages


### PR DESCRIPTION
According to the github-pages-deploy-action [4.4.1](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.4.1) release notes, this will fix some of the GitHub Actions warnings reported in issue #147