### PR TITLE
Checkout specific lcov release to avoid random build failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       run: |
         sudo apt-get install libperlio-gzip-perl libjson-perl
         pushd ~
-        git clone --depth=1 https://github.com/linux-test-project/lcov.git
+        git clone --depth=1 --branch=v1.16 https://github.com/linux-test-project/lcov.git
         pushd lcov
         make PREFIX=${LOCAL_INSTALL_PATH} install
         hash -r


### PR DESCRIPTION
This way we can decide when to update the dependency. Fixes issue #152 