### PR TITLE
Bump APERTURE_PARAMETERS_MAX to 10006

### DIFF
--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -86,11 +86,12 @@ extern "C" {
 #define APERTURE_MAX 9999
 
 /*
- * Maximum number of aperture parameters is set by the outline aperture
- * macro. There (p. 28) is defined up to 50 points in polygon.
- * So 50 points with x and y plus two for holding extra data gives...
+ * Maximum number of aperture parameters is set by the outline aperture macro.
+ * There (p. 62) is defined up to 5000 points in outline. So 5000 points with x
+ * and y plus outline shape code, exposure, # of vertices, and duplication of
+ * start/end point gives
  */
-#define APERTURE_PARAMETERS_MAX 102
+#define APERTURE_PARAMETERS_MAX 10006
 #define GERBV_SCALE_MIN 10
 #define GERBV_SCALE_MAX 3000
 #define MAX_ERRMSGLEN 25


### PR DESCRIPTION
Previously, this was set to only 102 and referenced an outdated version of the Gerber file format specification. As of revision 2021.02, the Gerber file format specification lists the maximum vertex count of an aperture macro outline as 5000, and thus the largest possible outline macro might have 10006 parameters.

Spec: https://www.ucamco.com/files/downloads/file_en/416/the-gerber-file-format-specification-revision-2020-09-update_en.pdf#page=62

Section 4.5.1.6:
> The maximum number of vertices is 5000. The purpose of this primitive is to create apertures to
flash pads with special shapes. The purpose is not to create copper pours. Use the region
statement for copper pours; see 4.10