### PR TITLE
Fix: crash Edit-file-format dialog

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -725,6 +725,7 @@ define_layer(scheme *sc, pointer args)
 
 		type = sc->vptr->symname (attr_type);
 
+		plist->attr_list[p].default_val.str_value = NULL;
 		if (strcmp (type, "label") == 0) {
 		    dprintf ("%s", sc->vptr->string_value (attr_value));
 		    plist->attr_list[p].type = HID_Label;


### PR DESCRIPTION
I found a fatal bug.
Gerbv crashed when opening from menubar [Layer]->[Edit file format] and closing the dialog with [OK] button.

This trouble is caused by accessing an uninitialized area of `attr_list[p].str_value`. The program expects NULL or proper strings in _attribute.c_ at line 530-531.

My test environment is Windows and I compiled with mingw-w64.
Here is the backtrace log by gdb:
```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x000007fefddc5350 in msvcrt!_strdup () from C:\Windows\system32\msvcrt.dll
(gdb) bt
#0  0x000007fefddc5350 in msvcrt!_strdup ()
   from C:\Windows\system32\msvcrt.dll
#1  0x0000000000402fb3 in attribute_interface_dialog (attrs=0x7b3b760,
    n_attrs=4, results=0x92005e0,
    title=0x7bae4e0 "ファイル形式?\201?編", <incomplete sequence \206>, descr=0x7b1bed0 "Excellon Drill File") at attribute.c:531
#2  0x000000000040b16e in callbacks_change_layer_format_clicked (
    button=0x575f020, user_data=0x0) at callbacks.c:2722
#3  0x000000000085677c in g_closure_invoke ()
#4  0x000000000086854a in signal_emit_unlocked_R ()
#5  0x0000000000871d20 in g_signal_emit_valist ()
#6  0x00000000008724a8 in g_signal_emit ()
#7  0x000000000058a388 in gtk_widget_activate ()
#8  0x00000000004df8c8 in gtk_menu_shell_activate_item ()
#9  0x00000000004dfb3d in gtk_menu_shell_button_release ()
#10 0x00000000004d11eb in _gtk_marshal_BOOLEAN__BOXED ()
#11 0x000000000085677c in g_closure_invoke ()
#12 0x0000000000867c55 in signal_emit_unlocked_R ()
#13 0x0000000000871a4a in g_signal_emit_valist ()
#14 0x00000000008724a8 in g_signal_emit ()
#15 0x00000000005889bd in gtk_widget_event_internal ()
#16 0x00000000004d0b41 in gtk_propagate_event ()
#17 0x00000000004d0eab in gtk_main_do_event ()
#18 0x0000000000625b0a in gdk_event_dispatch ()
#19 0x0000000000cdcfb4 in g_main_context_dispatch ()
#20 0x0000000000cdd1b8 in g_main_context_iterate.isra ()
#21 0x0000000000cdd5b3 in g_main_loop_run ()
#22 0x00000000004d0140 in gtk_main ()
#23 0x0000000000419733 in interface_create_gui (req_width=-1, req_height=-1)
    at interface.c:1843
#24 0x000000000041f8a7 in main (argc=1, argv=0x2db23b0) at main.c:1133
```
