### PR TITLE
Fix: Translation and Scale are not editable in Edit-layer dialog

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -2303,11 +2303,11 @@ interface_show_alert_dialog (gchar *primaryText, gchar *secondaryText,
 
 static int focused_widget_num = 0;
 
-int
+gboolean
 focus_in_event_callback (int *widget_num)
 {
 	focused_widget_num = *widget_num;
-	return 0;
+	return FALSE;
 }
 
 void

--- a/src/interface.c
+++ b/src/interface.c
@@ -2303,10 +2303,11 @@ interface_show_alert_dialog (gchar *primaryText, gchar *secondaryText,
 
 static int focused_widget_num = 0;
 
-void
+int
 focus_in_event_callback (int *widget_num)
 {
 	focused_widget_num = *widget_num;
+	return 0;
 }
 
 void


### PR DESCRIPTION
gerbv.exe compiled by mingw-w64 with MSYS2 on Windows , in the Edit-layer dialog that opens by [Layer]-[Edit layer], numerical values cannot be entered into the edit box from the keyboard.

According to https://stackoverflow.com/questions/58318673/gtk-window-is-active-not-working-as-expected , the event handler which handles "focus-in-event" should return 0 or 1:
+ If the event handler returns 1 (TRUE), the behavior is handled by that event handler.
+ If the event handler returns 0 (FALSE), the behavior is GTK's default behavior.

Yet *focus_in_event_callback* does not return a value (void).