### PR TITLE
Allow 'gerbv foo.gvp' to act like 'gerbv -p foo.gvp' was specified

### DIFF
--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -1114,3 +1114,11 @@ gerbv_transform_coord_for_image(double *x, double *y,
 	return 0;
 }
 
+gboolean
+gerbv_endswith(const char *path, const char *ext) {
+    int plen = strlen(path);
+    int elen = strlen(ext);
+    if ( plen < elen ) return FALSE;                    // false if string too short to check
+    return (strcmp(path+plen-elen, ext) == 0) ? TRUE    // true if last chars match extension
+                                              : FALSE;
+}

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -1105,6 +1105,10 @@ int
 gerbv_transform_coord_for_image(double *x, double *y,
 		const gerbv_image_t *image, const gerbv_project_t *project);
 
+/*! See if 'path' ends with the filename extension 'ext' */
+gboolean
+gerbv_endswith(const char *path, const char *ext);
+
 /*! Transform coordinate x and y */
 void
 gerbv_transform_coord(double *x, double *y,

--- a/src/main.c
+++ b/src/main.c
@@ -896,6 +896,15 @@ main(int argc, char *argv[])
 			    read_opt);
 	}
     }
+
+    /*
+     * If no project_filename and only file ends in .gvp, use as project file. -erco 02/20/2020
+     */
+    if ( !project_filename &&                       // project not set?
+         optind == (argc-1) &&                      // only one file specified?
+         gerbv_endswith(argv[optind], ".gvp") ) {   // only file ends in .gvp?
+        project_filename = argv[optind];
+    }
     
     /*
      * If project is given, load that one and use it for files and colors.


### PR DESCRIPTION
Allow .gvp file to open without -p option.
This is from [#76 Allow 'gerbv foo.gvp' to act like 'gerbv -p foo.gvp' was specified](https://sourceforge.net/p/gerbv/patches/76/) created by Greg Ercolano.

This patch resolves issue [#107](https://github.com/gerbv/gerbv/issues/107).