### PR TITLE
enable manual workflow initiation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
       - main
   pull_request:
     branches: [ main ]
-
+  workflow_dispatch:
 
 jobs:
   ci:


### PR DESCRIPTION
This just allows folks to manually initiate the CI action on their own forks, without needing to generate a PR.