### PR TITLE
Move pre-commit hook into utils directory

### DIFF
--- a/.mc/fedora_38/fedora_38.yaml
+++ b/.mc/fedora_38/fedora_38.yaml
@@ -11,6 +11,11 @@ install:
  - libtool
  - pkgconf
 
+ # clang-format
+ - clang-tools-extra
+ - patch
+ - python3
+
  # Runtime dependencies
  - cairo-devel
  - gtk2-devel

--- a/.mc/ubuntu_22.04/ubuntu_22.04.yaml
+++ b/.mc/ubuntu_22.04/ubuntu_22.04.yaml
@@ -10,6 +10,10 @@ install:
  - libtool
  - pkg-config
 
+ # clang-format
+ - clang-format
+ - python3
+
  # Runtime dependencies
  - libdxflib-dev
  - libgtk2.0-dev

--- a/clang-format-cache.py
+++ b/clang-format-cache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''clang format the files in the index (aka the staged files).'''
 

--- a/install-hooks
+++ b/install-hooks
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-mkdir -p .git/hooks
-ln -s ../../clang-format-cache.py ./.git/hooks/pre-commit

--- a/utils/clang-format-cache.py
+++ b/utils/clang-format-cache.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
-'''clang format the files in the index (aka the staged files).'''
+'''clang format the files in the index (aka the staged files).
+
+@see https://github.com/gerbv/gerbv/pull/203
+@author eyal0
+'''
 
 import os
 import re

--- a/utils/install-hooks
+++ b/utils/install-hooks
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# @see https://github.com/gerbv/gerbv/pull/203
+# @author eyal0
+
+
+# @see https://stackoverflow.com/a/246128
+DIRECTORY_OF_SCRIPT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+mkdir -p "${DIRECTORY_OF_SCRIPT}/../.git/hooks"
+ln -s "${DIRECTORY_OF_SCRIPT}/clang-format-cache.py" "${DIRECTORY_OF_SCRIPT}/../.git/hooks/pre-commit"
+


### PR DESCRIPTION
In order to keep the root directory clean, I propose to move the pre-commit hook into the utils directory. Moreover I explicitly stated the required Python version and added the clang-format dependencies to isolated build environments.

@eyal0 are you ok with this change?

See PR #203 