### PR TITLE
ci: Use upload artifact v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
 
     - name: Upload executable artifacts
       if: "!matrix.code_coverage"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: gerbv
         path: gerbv.github.io/ci/gerbv*


### PR DESCRIPTION
v3 is deprecated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/