### PR TITLE
Bugfixes and spellchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ cmake --build --preset mingw-w64-gcc
 
 To create another cross compilation target, check the directory `cmake/toolchains/`.
 
-To create another preset, check out the directory`cmake/preset/` and add the new preset file as an include in `CMakePreset.json`.
+To create another preset, check out the directory `cmake/preset/` and add the new preset file as an include in `CMakePreset.json`.
 
 ## Applied patches from SourceForge
 

--- a/cmake/GetGitVersion.cmake
+++ b/cmake/GetGitVersion.cmake
@@ -28,7 +28,7 @@ function(get_git_version var)
           set(GIT_VERSION "v0.0.0")
       else()
           string(STRIP ${GIT_VERSION} GIT_VERSION)
-          string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
+        #   string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
       endif()
       # Work out if the repository is dirty
       execute_process(COMMAND ${GIT_EXECUTABLE} update-index -q --refresh

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -5,3 +5,7 @@ Downloaded from https://github.com/erri120/Gettext-CMake/blob/master/Gettext_hel
 
 Reading the blog post at https://erri120.github.io/posts/2022-05-05/
 
+## GetGitVersion.cmake
+Returns a version string from Git tags
+
+From https://chromium.googlesource.com/external/github.com/google/benchmark/+/refs/tags/v1.4.1/cmake/GetGitVersion.cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,8 @@ install(TARGETS gerbv
 
 add_executable(gerbv-app)
 set_target_properties(gerbv-app PROPERTIES
-                     OUTPUT_NAME gerbv)
+                     OUTPUT_NAME gerbv
+                     PUBLIC_HEADER init.scm)
 target_sources(gerbv-app PRIVATE
                 attribute.c attribute.h
                 callbacks.c callbacks.h
@@ -65,7 +66,9 @@ target_sources(gerbv-app PRIVATE
 target_compile_definitions(gerbv-app PRIVATE $<$<BOOL:${DEBUG_PRINTOUT}>:DEBUG=1>)
 target_link_libraries(gerbv-app PRIVATE gerbv compilation-flags config generated)
 
-install(TARGETS gerbv-app)
+install(TARGETS gerbv-app
+        PUBLIC_HEADER
+            DESTINATION ${BACKEND_DIR})
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "\$\{prefix\}")


### PR DESCRIPTION
- Update README.md with trivial textual change
- Document GetGitVersion.cmake
- Update GetGitVersion.cmake to keep more of the version string
- Bugfix for not installing init.scm among all install() setups