### PR TITLE
feat: add optional Inkscape-layer SVG export

### DIFF
--- a/man/gerbv.1.in
+++ b/man/gerbv.1.in
@@ -86,6 +86,13 @@ the image to this size.
 .TP
 .BI -x<png/pdf/ps/svg/rs274x/drill>|--export=<png/pdf/ps/svg/rs274x/drill>   
 Export to a file and set the format for the output file.
+.TP
+.B --svg-layers
+Export visible layers as Inkscape SVG layers. This option is only used with
+.B -x svg
+or
+.B --export=svg
+.
 
 .SS GTK Options
 .BI --gtk-module= MODULE

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -547,7 +547,9 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 	GtkTooltips *tooltips;
 	GtkWidget *label;
 	GtkWidget *hbox;
+	GtkWidget *svg_layers_check;
 	static gint dpi = 0;
+	static gboolean svg_layers = FALSE;
 	
 	file_index = callbacks_get_selected_row_index ();
 	if (file_index < 0) {
@@ -568,10 +570,14 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 
 	hbox = gtk_hbox_new (0, 0);
 	spin_but = GTK_SPIN_BUTTON(gtk_spin_button_new_with_range (0, 0, 1));
+	svg_layers_check = gtk_check_button_new_with_label (_("Export as Inkscape layers"));
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (svg_layers_check), svg_layers);
 	label = gtk_label_new ("");
 	tooltips = gtk_tooltips_new ();
 	gtk_box_pack_end (GTK_BOX(hbox), GTK_WIDGET(spin_but), 0, 0, 1);
 	gtk_box_pack_end (GTK_BOX(hbox), label, 0, 0, 5);
+	gtk_box_pack_end (GTK_BOX(GTK_DIALOG(screen.win.gerber)->vbox),
+			svg_layers_check, 0, 0, 2);
 	gtk_box_pack_end (GTK_BOX(GTK_DIALOG(screen.win.gerber)->vbox),
 			hbox, 0, 0, 2);
 
@@ -633,6 +639,10 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 			error_visible_layers = TRUE;
 			break;
 		}
+
+		gtk_tooltips_set_tip (tooltips, GTK_WIDGET(svg_layers_check),
+				_("Create one Inkscape layer per visible gerber layer"), NULL);
+		gtk_widget_show_all (svg_layers_check);
 
 
 		break;
@@ -781,6 +791,8 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 	if (gtk_dialog_run (GTK_DIALOG(screen.win.gerber)) == GTK_RESPONSE_ACCEPT) {
 		new_file_name = gtk_file_chooser_get_filename (file_chooser_p);
 		dpi = gtk_spin_button_get_value_as_int (spin_but);
+		svg_layers = gtk_toggle_button_get_active (
+				GTK_TOGGLE_BUTTON (svg_layers_check));
 	}
 	gtk_widget_destroy (screen.win.gerber);
 
@@ -804,8 +816,8 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 				mainProject, new_file_name);
 		break;
 	case CALLBACKS_SAVE_FILE_SVG:
-		gerbv_export_svg_file_from_project_autoscaled (
-				mainProject, new_file_name);
+		gerbv_export_svg_file_from_project_autoscaled_with_options (
+				mainProject, new_file_name, svg_layers);
 		break;
 	case CALLBACKS_SAVE_FILE_DXF:
 #if HAVE_LIBDXFLIB

--- a/src/export-image.c
+++ b/src/export-image.c
@@ -42,6 +42,140 @@
 #include <cairo-pdf.h>
 #include <cairo-ps.h>
 #include <cairo-svg.h>
+#include <glib/gstdio.h>
+
+static gchar *
+exportimage_extract_svg_inner_content (const gchar *svgText) {
+	const gchar *svgOpen;
+	const gchar *svgOpenEnd;
+	const gchar *svgClose;
+
+	if (svgText == NULL)
+		return NULL;
+
+	svgOpen = strstr (svgText, "<svg");
+	if (svgOpen == NULL)
+		return NULL;
+
+	svgOpenEnd = strchr (svgOpen, '>');
+	if (svgOpenEnd == NULL)
+		return NULL;
+
+	svgClose = g_strrstr (svgOpenEnd, "</svg>");
+	if (svgClose == NULL || svgClose <= svgOpenEnd)
+		return NULL;
+
+	return g_strndup (svgOpenEnd + 1, svgClose - (svgOpenEnd + 1));
+}
+
+static void
+exportimage_append_svg_background (GString *svgOut, gerbv_project_t *gerbvProject) {
+	GdkColor *bg = &gerbvProject->background;
+
+	/* Keep legacy vector-export behavior: skip solid white/black backgrounds. */
+	if ((bg->red == 0xffff && bg->green == 0xffff && bg->blue == 0xffff)
+	 || (bg->red == 0x0000 && bg->green == 0x0000 && bg->blue == 0x0000))
+		return;
+
+	g_string_append_printf (svgOut,
+		"  <rect x=\"0\" y=\"0\" width=\"100%%\" height=\"100%%\" fill=\"rgb(%u,%u,%u)\" />\n",
+		bg->red / 257, bg->green / 257, bg->blue / 257);
+}
+
+static void
+exportimage_render_layer_to_svg_file (gerbv_fileinfo_t *fileInfo,
+		gerbv_render_info_t *renderInfo, const gchar *filename) {
+	cairo_surface_t *cSurface = cairo_svg_surface_create (filename,
+		renderInfo->displayWidth, renderInfo->displayHeight);
+	cairo_t *cairoTarget = cairo_create (cSurface);
+
+	gerbv_render_cairo_set_scale_and_translation (cairoTarget, renderInfo);
+	gerbv_render_layer_to_cairo_target_without_transforming (cairoTarget,
+		fileInfo, renderInfo, FALSE);
+
+	cairo_destroy (cairoTarget);
+	cairo_surface_destroy (cSurface);
+}
+
+static void
+exportimage_render_svg_layers_from_project (gerbv_project_t *gerbvProject,
+		gerbv_render_info_t *renderInfo, gchar const *filename) {
+	GString *svgOut = g_string_new (NULL);
+	gboolean hadError = FALSE;
+	int i;
+
+	g_string_append (svgOut, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+	g_string_append_printf (svgOut,
+		"<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:inkscape=\"http://www.inkscape.org/namespaces/inkscape\" version=\"1.1\" width=\"%d\" height=\"%d\" viewBox=\"0 0 %d %d\">\n",
+		renderInfo->displayWidth, renderInfo->displayHeight,
+		renderInfo->displayWidth, renderInfo->displayHeight);
+
+	exportimage_append_svg_background (svgOut, gerbvProject);
+
+	for (i = gerbvProject->last_loaded; i >= 0; i--) {
+		gerbv_fileinfo_t *fileInfo = gerbvProject->file[i];
+		gchar *tmpSvgName = NULL;
+		gchar *tmpSvgText = NULL;
+		gchar *innerSvg = NULL;
+		gchar *layerLabelEscaped = NULL;
+		gint tmpFd;
+
+		if (fileInfo == NULL || !fileInfo->isVisible)
+			continue;
+
+		tmpFd = g_file_open_tmp ("gerbv-svg-layer-XXXXXX.svg", &tmpSvgName, NULL);
+		if (tmpFd < 0 || tmpSvgName == NULL) {
+			GERB_COMPILE_ERROR (_("Exporting error to file \"%s\""), filename);
+			hadError = TRUE;
+			g_free (tmpSvgName);
+			break;
+		}
+		close (tmpFd);
+
+		exportimage_render_layer_to_svg_file (fileInfo, renderInfo, tmpSvgName);
+
+		if (!g_file_get_contents (tmpSvgName, &tmpSvgText, NULL, NULL)) {
+			GERB_COMPILE_ERROR (_("Exporting error to file \"%s\""), filename);
+			hadError = TRUE;
+			goto cleanup_layer_export;
+		}
+
+		innerSvg = exportimage_extract_svg_inner_content (tmpSvgText);
+		if (innerSvg == NULL) {
+			GERB_COMPILE_ERROR (_("Exporting error to file \"%s\""), filename);
+			hadError = TRUE;
+			goto cleanup_layer_export;
+		}
+
+		layerLabelEscaped = g_markup_escape_text (
+			fileInfo->name ? fileInfo->name : _("Unnamed layer"), -1);
+
+		g_string_append_printf (svgOut,
+			"  <g inkscape:groupmode=\"layer\" inkscape:label=\"%s\">\n",
+			layerLabelEscaped);
+		g_string_append (svgOut, innerSvg);
+		g_string_append (svgOut, "\n");
+		g_string_append (svgOut, "  </g>\n");
+
+	cleanup_layer_export:
+		g_free (layerLabelEscaped);
+		g_free (innerSvg);
+		g_free (tmpSvgText);
+		g_unlink (tmpSvgName);
+		g_free (tmpSvgName);
+
+		if (hadError)
+			break;
+	}
+
+	g_string_append (svgOut, "</svg>\n");
+
+	if (!hadError && !g_file_set_contents (filename, svgOut->str, svgOut->len, NULL)) {
+		GERB_COMPILE_ERROR (_("Exporting error to file \"%s\""), filename);
+	}
+
+	g_string_free (svgOut, TRUE);
+}
 
 void exportimage_render_to_surface_and_destroy (gerbv_project_t *gerbvProject,
 		cairo_surface_t *cSurface, gerbv_render_info_t *renderInfo, gchar const* filename) {
@@ -119,13 +253,30 @@ void gerbv_export_postscript_file_from_project (gerbv_project_t *gerbvProject, g
 
 void gerbv_export_svg_file_from_project_autoscaled (gerbv_project_t *gerbvProject, gchar const* filename) {
 	gerbv_render_info_t renderInfo = gerbv_export_autoscale_project(gerbvProject);
-	gerbv_export_svg_file_from_project (gerbvProject, &renderInfo, filename);
+	gerbv_export_svg_file_from_project_with_options (gerbvProject, &renderInfo, filename, FALSE);
 }
 
 void gerbv_export_svg_file_from_project (gerbv_project_t *gerbvProject, gerbv_render_info_t *renderInfo,
 		gchar const* filename) {
+	gerbv_export_svg_file_from_project_with_options (gerbvProject, renderInfo, filename, FALSE);
+}
+
+void gerbv_export_svg_file_from_project_autoscaled_with_options (gerbv_project_t *gerbvProject,
+		gchar const* filename, gboolean exportLayersAsSvgLayers) {
+	gerbv_render_info_t renderInfo = gerbv_export_autoscale_project(gerbvProject);
+	gerbv_export_svg_file_from_project_with_options (gerbvProject, &renderInfo, filename,
+		exportLayersAsSvgLayers);
+}
+
+void gerbv_export_svg_file_from_project_with_options (gerbv_project_t *gerbvProject,
+		gerbv_render_info_t *renderInfo, gchar const* filename,
+		gboolean exportLayersAsSvgLayers) {
+	if (exportLayersAsSvgLayers) {
+		exportimage_render_svg_layers_from_project (gerbvProject, renderInfo, filename);
+		return;
+	}
+
 	cairo_surface_t *cSurface = cairo_svg_surface_create (filename, renderInfo->displayWidth,
 								renderInfo->displayHeight);
       exportimage_render_to_surface_and_destroy (gerbvProject, cSurface, renderInfo, filename);
 }
-

--- a/src/export-image.c
+++ b/src/export-image.c
@@ -50,20 +50,24 @@ exportimage_extract_svg_inner_content (const gchar *svgText) {
 	const gchar *svgOpenEnd;
 	const gchar *svgClose;
 
-	if (svgText == NULL)
+	if (svgText == NULL) {
 		return NULL;
+	}
 
 	svgOpen = strstr (svgText, "<svg");
-	if (svgOpen == NULL)
+	if (svgOpen == NULL) {
 		return NULL;
+	}
 
 	svgOpenEnd = strchr (svgOpen, '>');
-	if (svgOpenEnd == NULL)
+	if (svgOpenEnd == NULL) {
 		return NULL;
+	}
 
 	svgClose = g_strrstr (svgOpenEnd, "</svg>");
-	if (svgClose == NULL || svgClose <= svgOpenEnd)
+	if (svgClose == NULL || svgClose <= svgOpenEnd) {
 		return NULL;
+	}
 
 	return g_strndup (svgOpenEnd + 1, svgClose - (svgOpenEnd + 1));
 }
@@ -72,10 +76,15 @@ static void
 exportimage_append_svg_background (GString *svgOut, gerbv_project_t *gerbvProject) {
 	GdkColor *bg = &gerbvProject->background;
 
-	/* Keep legacy vector-export behavior: skip solid white/black backgrounds. */
+	/*
+	 * Keep background behavior aligned with existing vector export: we only emit
+	 * a background rectangle for non-white/non-black colors, so pure white/black
+	 * stay transparent like the non-layered SVG path.
+	 */
 	if ((bg->red == 0xffff && bg->green == 0xffff && bg->blue == 0xffff)
-	 || (bg->red == 0x0000 && bg->green == 0x0000 && bg->blue == 0x0000))
+	 || (bg->red == 0x0000 && bg->green == 0x0000 && bg->blue == 0x0000)) {
 		return;
+	}
 
 	g_string_append_printf (svgOut,
 		"  <rect x=\"0\" y=\"0\" width=\"100%%\" height=\"100%%\" fill=\"rgb(%u,%u,%u)\" />\n",
@@ -120,8 +129,9 @@ exportimage_render_svg_layers_from_project (gerbv_project_t *gerbvProject,
 		gchar *layerLabelEscaped = NULL;
 		gint tmpFd;
 
-		if (fileInfo == NULL || !fileInfo->isVisible)
+		if (fileInfo == NULL || !fileInfo->isVisible) {
 			continue;
+		}
 
 		tmpFd = g_file_open_tmp ("gerbv-svg-layer-XXXXXX.svg", &tmpSvgName, NULL);
 		if (tmpFd < 0 || tmpSvgName == NULL) {
@@ -164,8 +174,9 @@ exportimage_render_svg_layers_from_project (gerbv_project_t *gerbvProject,
 		g_unlink (tmpSvgName);
 		g_free (tmpSvgName);
 
-		if (hadError)
+		if (hadError) {
 			break;
+		}
 	}
 
 	g_string_append (svgOut, "</svg>\n");

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -968,12 +968,29 @@ gerbv_export_svg_file_from_project_autoscaled (
 		gchar const* filename  /*!< the filename for the exported   file */
 );
 
+//! Render a project to a SVG file, optionally exporting visible layers as Inkscape layers
+void
+gerbv_export_svg_file_from_project_autoscaled_with_options (
+		gerbv_project_t *gerbvProject, /*!< the project to render */
+		gchar const* filename, /*!< the filename for the exported file */
+		gboolean exportLayersAsSvgLayers /*!< TRUE to emit Inkscape layer groups */
+);
+
 //! Render a project to a   file using user-specified render info
 void
 gerbv_export_svg_file_from_project (
 		gerbv_project_t *gerbvProject, /*!< the project to render */
 		gerbv_render_info_t *renderInfo, /*!< the render settings for the rendered image */
 		gchar const* filename /*!< the filename for the exported   file */
+);
+
+//! Render a project to a SVG file using user-specified render info and export options
+void
+gerbv_export_svg_file_from_project_with_options (
+		gerbv_project_t *gerbvProject, /*!< the project to render */
+		gerbv_render_info_t *renderInfo, /*!< the render settings for the rendered image */
+		gchar const* filename, /*!< the filename for the exported file */
+		gboolean exportLayersAsSvgLayers /*!< TRUE to emit Inkscape layer groups */
 );
 
 //! Export an image to a new file in DXF format

--- a/src/main.c
+++ b/src/main.c
@@ -145,6 +145,7 @@ const struct option longopts[] = {
     {"units",           required_argument,  NULL,    'u'},
     {"window",		required_argument,  NULL,    'w'},
     {"export",          required_argument,  NULL,    'x'},
+    {"svg-layers",      no_argument,        &longopt_val, 3},
     {"geometry",        required_argument,  &longopt_val, 1},
     /* GDK/GDK debug flags to be "let through" */
     {"gtk-module",      required_argument,  &longopt_val, 2},
@@ -435,6 +436,7 @@ main(int argc, char *argv[])
     int unit_flag_counter;
     gboolean initial_mirror_x = FALSE;
     gboolean initial_mirror_y = FALSE;
+    gboolean svgLayers = FALSE;
     const gchar *exportFilename = NULL;
     gfloat userSuppliedOriginX=0.0,userSuppliedOriginY=0.0,userSuppliedDpiX=72.0, userSuppliedDpiY=72.0, 
 	   userSuppliedWidth=0, userSuppliedHeight=0,
@@ -612,6 +614,9 @@ main(int argc, char *argv[])
 		    break;
 		}
 		*/
+		break;
+	    case 3: /* svg-layers */
+		svgLayers = TRUE;
 		break;
 	    default:
 		break;
@@ -1065,8 +1070,8 @@ main(int argc, char *argv[])
 			    &renderInfo, exportFilename);
 	    break;
 	case EXP_TYPE_SVG:
-	    gerbv_export_svg_file_from_project(mainProject,
-			    &renderInfo, exportFilename);
+	    gerbv_export_svg_file_from_project_with_options(mainProject,
+			    &renderInfo, exportFilename, svgLayers);
 	    break;
 	case EXP_TYPE_PS:
 	    gerbv_export_postscript_file_from_project(mainProject,
@@ -1350,11 +1355,17 @@ gerbv_print_help(void)
 "  -x, --export=<png|pdf|ps|svg|rs274x|drill|idrill>\n"
 "                          Export a rendered picture to a file with\n"
 "                          the specified format.\n"));
+	printf(_(
+"      --svg-layers       Export visible layers as Inkscape SVG layers.\n"
+"                          Only used with --export=svg.\n"));
 #else
 	printf(_(
 "  -x<png|pdf|ps|svg|      Export a rendered picture to a file with\n"
 "     rs274x|drill|        the specified format.\n"
 "     idrill>\n"));
+	printf(_(
+"      --svg-layers       Export visible layers as Inkscape SVG layers.\n"
+"                          Only used with -xsvg.\n"));
 #endif
 
 }


### PR DESCRIPTION
note: this is generated code, prompt as follows
> add option in svg export to output all gerber layers as svg layers, in inkscape style.

given the quality of this project, and lack of deep understanding from my side i cannot say this is valid PR. 
it does work on my tests and is a feature i was craving for ages.  
might be of interest to others. 

<img width="1212" height="961" alt="image" src="https://github.com/user-attachments/assets/f2adff0c-3e37-48c7-aac1-cdd39e82b730" />

---
Add a new SVG export option that preserves visible Gerber layers as Inkscape layers so exported artwork remains editable by layer. Wire the option into both CLI and GUI export flows and document usage in help/man text.