### PR TITLE
fix: add DXF image export to CLI

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -453,7 +453,9 @@ main(int argc, char *argv[])
 	EXP_TYPE_RS274X,
 	EXP_TYPE_DRILL,
 	EXP_TYPE_IDRILL,
+#ifdef HAVE_LIBDXFLIB
 	EXP_TYPE_DXF,
+#endif
     };
     enum exp_type exportType = EXP_TYPE_NONE;
     const char *export_type_names[] = {
@@ -464,7 +466,9 @@ main(int argc, char *argv[])
 	"rs274x",
 	"drill",
 	"idrill",
+#ifdef HAVE_LIBDXFLIB
 	"dxf",
+#endif
 	NULL
     };
     const gchar *export_def_file_names[] = {
@@ -475,7 +479,9 @@ main(int argc, char *argv[])
 	"output.gbx",
 	"output.cnc",
 	"output.ncp",
+#ifdef HAVE_LIBDXFLIB
 	"output.dxf",
+#endif
 	NULL
     };
 
@@ -1083,7 +1089,9 @@ main(int argc, char *argv[])
 	case EXP_TYPE_RS274X:
 	case EXP_TYPE_DRILL:
 	case EXP_TYPE_IDRILL:
+#ifdef HAVE_LIBDXFLIB
 	case EXP_TYPE_DXF:
+#endif
 	    if (!mainProject->file[0]->image) {
 		fprintf(stderr, _("A valid file was not loaded.\n"));
 		exit(1);
@@ -1113,10 +1121,12 @@ main(int argc, char *argv[])
 		gerbv_export_isel_drill_file_from_image (exportFilename,
 			exportImage, &mainProject->file[0]->transform);
 		break;
+#ifdef HAVE_LIBDXFLIB
 	    case EXP_TYPE_DXF:
 		gerbv_export_dxf_file_from_image(exportFilename,
 			exportImage, &mainProject->file[0]->transform);
 		break;
+#endif
 	    default:
 		break;
 	    }
@@ -1360,7 +1370,11 @@ gerbv_print_help(void)
 
 #ifdef HAVE_GETOPT_LONG
 	printf(_(
+#ifdef HAVE_LIBDXFLIB
 "  -x, --export=<png|pdf|ps|svg|rs274x|drill|idrill|dxf>\n"
+#else
+"  -x, --export=<png|pdf|ps|svg|rs274x|drill|idrill>\n"
+#endif
 "                          Export a rendered picture to a file with\n"
 "                          the specified format.\n"));
 	printf(_(
@@ -1370,7 +1384,12 @@ gerbv_print_help(void)
 	printf(_(
 "  -x<png|pdf|ps|svg|      Export a rendered picture to a file with\n"
 "     rs274x|drill|        the specified format.\n"
-"     idrill|dxf>\n"));
+#ifdef HAVE_LIBDXFLIB
+"     idrill|dxf>\n"
+#else
+"     idrill>\n"
+#endif
+));
 	printf(_(
 "      --svg-layers       Export visible layers as Inkscape SVG layers.\n"
 "                          Only used with -xsvg.\n"));

--- a/src/main.c
+++ b/src/main.c
@@ -453,6 +453,7 @@ main(int argc, char *argv[])
 	EXP_TYPE_RS274X,
 	EXP_TYPE_DRILL,
 	EXP_TYPE_IDRILL,
+	EXP_TYPE_DXF,
     };
     enum exp_type exportType = EXP_TYPE_NONE;
     const char *export_type_names[] = {
@@ -463,6 +464,7 @@ main(int argc, char *argv[])
 	"rs274x",
 	"drill",
 	"idrill",
+	"dxf",
 	NULL
     };
     const gchar *export_def_file_names[] = {
@@ -473,6 +475,7 @@ main(int argc, char *argv[])
 	"output.gbx",
 	"output.cnc",
 	"output.ncp",
+	"output.dxf",
 	NULL
     };
 
@@ -1080,6 +1083,7 @@ main(int argc, char *argv[])
 	case EXP_TYPE_RS274X:
 	case EXP_TYPE_DRILL:
 	case EXP_TYPE_IDRILL:
+	case EXP_TYPE_DXF:
 	    if (!mainProject->file[0]->image) {
 		fprintf(stderr, _("A valid file was not loaded.\n"));
 		exit(1);
@@ -1107,6 +1111,10 @@ main(int argc, char *argv[])
 		break;
 	    case EXP_TYPE_IDRILL:
 		gerbv_export_isel_drill_file_from_image (exportFilename,
+			exportImage, &mainProject->file[0]->transform);
+		break;
+	    case EXP_TYPE_DXF:
+		gerbv_export_dxf_file_from_image(exportFilename,
 			exportImage, &mainProject->file[0]->transform);
 		break;
 	    default:
@@ -1352,7 +1360,7 @@ gerbv_print_help(void)
 
 #ifdef HAVE_GETOPT_LONG
 	printf(_(
-"  -x, --export=<png|pdf|ps|svg|rs274x|drill|idrill>\n"
+"  -x, --export=<png|pdf|ps|svg|rs274x|drill|idrill|dxf>\n"
 "                          Export a rendered picture to a file with\n"
 "                          the specified format.\n"));
 	printf(_(
@@ -1362,7 +1370,7 @@ gerbv_print_help(void)
 	printf(_(
 "  -x<png|pdf|ps|svg|      Export a rendered picture to a file with\n"
 "     rs274x|drill|        the specified format.\n"
-"     idrill>\n"));
+"     idrill|dxf>\n"));
 	printf(_(
 "      --svg-layers       Export visible layers as Inkscape SVG layers.\n"
 "                          Only used with -xsvg.\n"));


### PR DESCRIPTION
Cherry-pick of PR #228 by @snhobbs, rebased onto `develop` with conflict resolution. Based on #228 

Closes #227.

Adds `--export=dxf` to the CLI. Calls `gerbv_export_dxf_file_from_image()` (already present in `export-dxf.cpp`). The `#ifndef ENABLE_DXF` stub was dropped — DXF export is always available.

Original commit by Simon Hobbs (@snhobbs), 2023-11-24, preserved in git history.

Co-authored-by: snhobbs <simon.hobbs@electrooptical.net>
