### PR TITLE
Wire NOTE messages into CLI output with severity prefixes

### DIFF
--- a/man/gerbv.1.in
+++ b/man/gerbv.1.in
@@ -35,7 +35,11 @@ with Cairo) it can be specified as an #RRGGBBAA code. Use multiple
 \-f flags to set the color for multiple layers.
 .TP
 .BI -l\ <filename>|--log=<filename>
-All error messages etc are stored in a file with filename \fI<filename>\fP.
+Write all messages (with severity prefixes) to \fI<filename>\fP in addition
+to stderr.
+.TP
+.BI -q|--quiet
+Suppress note-level and debug messages on stderr and in the log file.
 .TP
 .BI -t\ <filename>|--tools=<filename>
 Read Excellon tools from the file \fI<filename>\fP.

--- a/src/gerb_stats.c
+++ b/src/gerb_stats.c
@@ -318,6 +318,7 @@ gerbv_stats_add_error(gerbv_error_list_t *error_list_in,
             GERB_COMPILE_WARNING("%s",error_text);
             break;
         case GERBV_MESSAGE_NOTE:
+            GERB_NOTE("%s", error_text);
             break;
     }
 

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -121,6 +121,7 @@ extern "C" {
 #define GERB_COMPILE_ERROR(...)  g_log(NULL, G_LOG_LEVEL_CRITICAL, __VA_ARGS__)
 #define GERB_COMPILE_WARNING(...)  g_log(NULL, G_LOG_LEVEL_WARNING, __VA_ARGS__)
 #define GERB_MESSAGE(...)  g_log(NULL, G_LOG_LEVEL_MESSAGE, __VA_ARGS__)
+#define GERB_NOTE(...)  g_log(NULL, G_LOG_LEVEL_INFO, __VA_ARGS__)
 
 /*! The aperture macro commands */  
 typedef enum {GERBV_OPCODE_NOP, /*!< no operation */

--- a/src/main.c
+++ b/src/main.c
@@ -137,6 +137,7 @@ const struct option longopts[] = {
     {"rotate",          required_argument,  NULL,    'r'},
     {"mirror",          required_argument,  NULL,    'm'},
     {"help",            no_argument,	    NULL,    'h'},
+    {"quiet",           no_argument,        NULL,    'q'},
     {"log",             required_argument,  NULL,    'l'},
     {"output",          required_argument,  NULL,    'o'},
     {"project",         required_argument,  NULL,    'p'},
@@ -162,7 +163,7 @@ const struct option longopts[] = {
     {0, 0, 0, 0},
 };
 #endif /* HAVE_GETOPT_LONG*/
-const char *opt_options = "VadhB:D:O:W:b:f:r:m:l:o:p:t:T:u:w:x:";
+const char *opt_options = "VadqhB:D:O:W:b:f:r:m:l:o:p:t:T:u:w:x:";
 
 /**Global state variable to keep track of what's happening on the screen.
    Declared extern in main.h
@@ -172,6 +173,8 @@ gerbv_screen_t screen;
 
 gboolean logToFileOption;
 gchar *logToFileFilename;
+static gboolean quietMode = FALSE;
+static FILE *logFile = NULL;
 
 /* Coords like "0x2" parsed by "%fx%f" will result in first number = 2 and
    second number 0. Replace 'x' in coordinate string with ';'*/
@@ -370,19 +373,44 @@ main_save_as_project_from_filename(gerbv_project_t *gerbvProject, gchar *filenam
 GArray *log_array_tmp = NULL;
 
 /* Temporary log messages handler. It will store log messages before GUI
- * initialization. */
+ * initialization. In CLI mode this is the only handler, so it also formats
+ * messages for stderr with clean severity prefixes and respects --quiet. */
 void
 callbacks_temporary_handle_log_messages(const gchar *log_domain,
 		GLogLevelFlags log_level,
 		const gchar *message, gpointer user_data) {
     struct log_struct item;
+    GLogLevelFlags level = log_level & G_LOG_LEVEL_MASK;
 
+    /* Store for GUI replay */
     item.domain = g_strdup (log_domain);
     item.level = log_level;
     item.message = g_strdup (message);
     g_array_append_val (log_array_tmp, item);
 
-    g_log_default_handler (log_domain, log_level, message, user_data);
+    /* Print unless suppressed by quiet mode (INFO = note, DEBUG) */
+    if (!(quietMode && (level & (G_LOG_LEVEL_INFO | G_LOG_LEVEL_DEBUG)))) {
+	const gchar *prefix;
+
+	switch (level) {
+	case G_LOG_LEVEL_ERROR:    prefix = "fatal";   break;
+	case G_LOG_LEVEL_CRITICAL: prefix = "error";   break;
+	case G_LOG_LEVEL_WARNING:  prefix = "warning"; break;
+	case G_LOG_LEVEL_MESSAGE:  prefix = "info";    break;
+	case G_LOG_LEVEL_INFO:     prefix = "note";    break;
+	case G_LOG_LEVEL_DEBUG:    prefix = "debug";   break;
+	default:                   prefix = "log";     break;
+	}
+
+	fprintf(stderr, "%s: %s\n", prefix, message);
+
+	if (logFile)
+	    fprintf(logFile, "%s: %s\n", prefix, message);
+    }
+
+    /* GLib expects the default handler to abort on fatal errors */
+    if (log_level & G_LOG_FLAG_FATAL)
+	g_log_default_handler (log_domain, log_level, message, user_data);
 }
 
 #ifdef WIN32
@@ -554,12 +582,15 @@ main(int argc, char *argv[])
 		    callbacks_temporary_handle_log_messages, NULL);
 
 
-    /* 1. Process "length unit" command line flag */
+    /* 1. Process flags needed before main option parsing */
     unit_flag_counter = 0;
     opterr = 0; /* Disable getopt() error messages */
     while (-1 != (read_opt = getopt_configured(argc, argv, opt_options,
 				    longopts, &longopt_idx))) {
 	switch (read_opt) {
+	case 'q':
+	    quietMode = TRUE;
+	    break;
 	case 'u':
 	    unit_flag_counter++;
 
@@ -898,6 +929,9 @@ main(int argc, char *argv[])
 	case 'd':
 	    screen.dump_parsed_image = 1;
 	    break;
+	case 'q':
+	    quietMode = TRUE;
+	    break;
 	case '?':
 	case 'h':
 	    gerbv_print_help();
@@ -908,6 +942,15 @@ main(int argc, char *argv[])
 	    /* This should not be reached */
 	    GERB_COMPILE_WARNING(_("Not handled option '%c' in command line"),
 			    read_opt);
+	}
+    }
+
+    if (logToFileOption) {
+	logFile = fopen(logToFileFilename, "w");
+	if (!logFile) {
+	    fprintf(stderr, "error: cannot open log file '%s'\n",
+		    logToFileFilename);
+	    exit(1);
 	}
     }
 
@@ -1094,6 +1137,8 @@ main(int argc, char *argv[])
 #endif
 	    if (!mainProject->file[0]->image) {
 		fprintf(stderr, _("A valid file was not loaded.\n"));
+		if (logFile)
+		    fclose(logFile);
 		exit(1);
 	    }
 
@@ -1135,18 +1180,24 @@ main(int argc, char *argv[])
 	    break;
 	default:
 	    fprintf(stderr, _("A valid file was not loaded.\n"));
+	    if (logFile)
+		fclose(logFile);
 	    exit(1);
 	}
 
 	/* exit now and don't start up gtk if this is a command line export */
+	if (logFile)
+	    fclose(logFile);
 	exit(0);
     }
     gtk_init (&argc, &argv);
     interface_create_gui (req_width, req_height);
-    
+
     /* we've exited the GTK loop, so free all resources */
     render_free_screen_resources();
     gerbv_destroy_project (mainProject);
+    if (logFile)
+	fclose(logFile);
     return 0;
 } /* main */
 
@@ -1295,6 +1346,14 @@ gerbv_print_help(void)
 #else
 	printf(_(
 "  -l<logfile>             Send error messages to <logfile>.\n"));
+#endif
+
+#ifdef HAVE_GETOPT_LONG
+	printf(_(
+"  -q, --quiet             Suppress note-level messages.\n"));
+#else
+	printf(_(
+"  -q                      Suppress note-level messages.\n"));
 #endif
 
 #ifdef HAVE_GETOPT_LONG


### PR DESCRIPTION
## Summary

- Add `GERB_NOTE` macro (`G_LOG_LEVEL_INFO`) and emit NOTE messages through `g_log` in `gerb_stats.c`
- Replace `g_log_default_handler` passthrough with a custom formatter that prints clean `fatal:`/`error:`/`warning:`/`note:` prefixes to stderr
- Add `--quiet`/`-q` flag to suppress note-level messages
- Wire up the existing `--log`/`-l` flag to actually write prefixed messages to a file

## Context

PR #282 (Gerber X2 attributes) added `GERBV_MESSAGE_NOTE` messages for X2 attribute commands. The `NOTE` case in `gerbv_stats_add_error()` had a `break` with no `g_log()` call — messages were stored in the error list but never emitted to stderr. Messages that did reach stderr used GLib's default format (`** (process): WARNING **: text`) with no clean prefix. The `--log` flag was parsed but never connected.

## Changes

**`src/gerbv.h`** — `GERB_NOTE(...)` macro mapping to `G_LOG_LEVEL_INFO`

**`src/gerb_stats.c`** — Wire empty `GERBV_MESSAGE_NOTE` case to `GERB_NOTE()`

**`src/main.c`**:
- Custom `callbacks_temporary_handle_log_messages` that formats with severity prefixes, respects `--quiet`, writes to log file, and preserves `log_array_tmp` for GUI replay
- `--quiet`/`-q` option (longopts, opt_options, switch case, help text)
- `--log`/`-l` file open after option parsing, `fclose` on both CLI exit and GUI return paths

## Test plan

- [x] Build: `cd build && cmake .. && make` — clean, no warnings
- [x] X2 file without `--quiet`: shows `note: Ignoring Gerber X2 attribute...`
- [x] X2 file with `--quiet`: note suppressed, no output
- [x] Bad file: `error:` and `warning:` prefixes shown correctly
- [x] `--log /tmp/gerbv.log`: log file written with prefixed messages
- [x] Test suite: 94 passed, 10 pre-existing rendering mismatches (unrelated)

Fixes #291