### PR TITLE
fix: add bounds-check guards for file reading functions

### DIFF
--- a/src/gerb_file.c
+++ b/src/gerb_file.c
@@ -102,12 +102,27 @@ gerb_fopen(char const * filename)
 
     dprintf("     Doing mmap\n");
     fd->datalen = (int)statinfo.st_size;
-    fd->data = (char *)mmap(0, statinfo.st_size, PROT_READ, MAP_PRIVATE, 
+    fd->data = (char *)mmap(0, statinfo.st_size, PROT_READ, MAP_PRIVATE,
 			    fd->fileno, 0);
     if(fd->data == MAP_FAILED) {
 	fclose(fd->fd);
 	g_free(fd);
 	fd = NULL;
+    } else {
+	/* Copy into a heap buffer with null terminator so strtol/strtod
+	 * have a safe stopping point — mmap does not guarantee '\0'
+	 * after the file content. */
+	char *buf = (char *)g_malloc(fd->datalen + 1);
+	if (buf == NULL) {
+	    munmap(fd->data, fd->datalen);
+	    fclose(fd->fd);
+	    g_free(fd);
+	    return NULL;
+	}
+	memcpy(buf, fd->data, fd->datalen);
+	buf[fd->datalen] = '\0';
+	munmap(fd->data, fd->datalen);
+	fd->data = buf;
     }
 
 #else
@@ -155,7 +170,13 @@ gerb_fgetint(gerb_file_t *fd, int *len)
 {
     long int result;
     char *end;
-    
+
+    if (fd->ptr >= fd->datalen) {
+	if (len)
+	    *len = 0;
+	return 0;
+    }
+
     errno = 0;
     result = strtol(fd->data + fd->ptr, &end, 10);
     if (errno) {
@@ -179,15 +200,23 @@ gerb_fgetint(gerb_file_t *fd, int *len)
 double
 gerb_fgetdouble(gerb_file_t *fd)
 {
-    char *start = fd->data + fd->ptr;
+    char *start;
+    int remaining;
     double result;
     char *end;
+
+    if (fd->ptr >= fd->datalen)
+	return 0.0;
+
+    start = fd->data + fd->ptr;
+    remaining = fd->datalen - fd->ptr;
 
     /* Prevent strtod from consuming hex float notation (0x.../0X...).
      * In Gerber aperture macros, x/X is the multiplication operator,
      * so "0X25.4" must parse as "0" followed by "X25.4", not as a
      * hexadecimal floating-point literal. */
-    if (start[0] == '0' && (start[1] == 'x' || start[1] == 'X')) {
+    if (remaining >= 2
+	    && start[0] == '0' && (start[1] == 'x' || start[1] == 'X')) {
 	fd->ptr += 1;
 	return 0.0;
     }
@@ -253,12 +282,10 @@ gerb_fclose(gerb_file_t *fd)
     if (fd) {
         g_free(fd->filename);
 
-#ifdef HAVE_SYS_MMAN_H
-	if (munmap(fd->data, fd->datalen) < 0)
-	    GERB_FATAL_ERROR("munmap: %s", strerror(errno));
-#else
+	/* fd->data is always heap-allocated: the mmap path now copies
+	 * into a g_malloc'd buffer (for null termination) before
+	 * munmap, and the non-mmap path uses calloc. */
 	g_free(fd->data);
-#endif   
 	if (fclose(fd->fd) == EOF)
 	    GERB_FATAL_ERROR("fclose: %s", strerror(errno));
 	g_free(fd);


### PR DESCRIPTION
## Summary

`gerb_file_t` has two allocation paths in `gerb_fopen()`:

- **mmap path** (Linux/macOS): buffer is exactly `st_size` bytes with **no null terminator**
- **calloc path** (Windows): buffer has a null terminator at `data[datalen]`

`strtol()` and `strtod()` scan forward until they hit a non-matching character or `'\0'`. On the mmap path, if a file ends with digits and no trailing newline/command, these functions can read past the mapped region.

Additionally, `gerb_fgetdouble()` accesses `start[0]`/`start[1]` for the hex-float guard (added in #285) without checking that at least 2 bytes remain.

This PR:

- **Copies mmap'd data into a heap buffer with `'\0'` terminator** before `munmap`, making both code paths produce identical null-terminated buffers
- **Simplifies `gerb_fclose()`** — `fd->data` is now always heap-allocated, so the `#ifdef`/`munmap` branch is removed
- **Adds early-return guards** to `gerb_fgetint()` and `gerb_fgetdouble()` when the read pointer is at or past end-of-data
- **Guards the hex-float check** in `gerb_fgetdouble()` with `remaining >= 2` before accessing `start[1]`

## Affected functions

| Function | Fix |
|----------|-----|
| `gerb_fopen()` | Null-terminate mmap buffer via heap copy |
| `gerb_fclose()` | Remove `munmap` branch, use `g_free()` unconditionally |
| `gerb_fgetint()` | Early return at end-of-data |
| `gerb_fgetdouble()` | Early return at end-of-data + bounds-check hex guard |

Already safe (unchanged): `gerb_fgetc()` (checks `ptr >= datalen`), `gerb_fgetstring()` (uses `iend` bound).

## Testing

- Clean build, no new warnings
- 94/104 tests pass (same 10 pre-existing rendering mismatches, unrelated)
- Hex-expression test (`test-amacro-hex-expression.gbx`) renders correctly
- X2 attributes test (`test-gerber-x2-attributes.gbx`) renders correctly
- Truncated file ending in digits with no trailing newline — no crash