### PR TITLE
Fix all implicit case fallthrough (#287)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(SCMSUBDIR "scheme")
 set(BACKEND_DIR "${DATADIR}/${SCMSUBDIR}")
 
 add_library(compilation-flags INTERFACE)
-target_compile_options(compilation-flags INTERFACE -Wall -O3 -Wno-deprecated-declarations)
+target_compile_options(compilation-flags INTERFACE -Wall -Wimplicit-fallthrough -O3 -Wno-deprecated-declarations)
 target_compile_options(compilation-flags INTERFACE $<$<CONFIG:Debug>:-g3>)
 target_link_libraries(compilation-flags INTERFACE PkgConfig::GLIB PkgConfig::GTK m)
 if(DXF_FOUND)

--- a/src/amacro.c
+++ b/src/amacro.c
@@ -258,6 +258,7 @@ parse_aperture_macro(gerb_file_t *fd)
 		c = gerb_fgetc(fd); /* Read the '*' */
 		break;
 	    }
+	    [[fallthrough]];
 	case '1':
 	case '2':
 	case '3':

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -697,6 +697,7 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 			error_visible_layers = TRUE;
 			break;
 		}
+		break;
 	case CALLBACKS_SAVE_FILE_DRILL:
 		windowTitle = g_strdup_printf(
 			_("Export \"%s\" layer #%d to "
@@ -1052,7 +1053,7 @@ callbacks_toggle_layer_visibility_activate (GtkMenuItem *menuitem, gpointer user
 	switch (i) {
 	case LAYER_SELECTED:
 		i = callbacks_get_selected_row_index ();
-		/* No break */
+		[[fallthrough]];
 	default:
 		if (0 <= i && i <= mainProject->last_loaded) {
 			mainProject->file[i]->isVisible = !mainProject->file[i]->isVisible;

--- a/src/csv.c
+++ b/src/csv.c
@@ -144,6 +144,7 @@ csv_parse_str(struct sinput *in, char *buf, size_t bn, char *row[], int rn, int 
 					break;
 				}
 				state = ST_COLLECT;
+				[[fallthrough]];
 			case ST_COLLECT:
 				if (inquotes) {
 					if (ch == '"') {
@@ -266,6 +267,7 @@ csv_parse_wcs(struct winput *in, wchar_t *buf, size_t bn, wchar_t *row[], int rn
 					break;
 				}
 				state = ST_COLLECT;
+				[[fallthrough]];
 			case ST_COLLECT:
 				if (inquotes) {
 					if (ch == L'"') {

--- a/src/drill.c
+++ b/src/drill.c
@@ -873,6 +873,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	      }
 	      
 	    }
+	    break;
 
 	case 'S':
 	    gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_NOTE, -1,

--- a/src/main.c
+++ b/src/main.c
@@ -859,6 +859,7 @@ main(int argc, char *argv[])
 
 	case 'w':
 	    userSuppliedWindowInPixels = TRUE;
+	    [[fallthrough]];
     	case 'W' :
 	    if (optarg == NULL) {
 		fprintf(stderr, _("You must give a window size in the format <width x height>.\n"));


### PR DESCRIPTION
## Summary

- Enable `-Wimplicit-fallthrough` in `CMakeLists.txt` compiler flags
- Annotate all intentional case fallthroughs with C23 `[[fallthrough]];` attribute

## Changes

| File | Location | Fallthrough |
|------|----------|-------------|
| `src/amacro.c` | `case '0':` → `case '1':` | Comment is conditionally consumed, otherwise falls through to digit parsing |
| `src/callbacks.c` | `SAVE_FILE_RS274XM` → `SAVE_FILE_DRILL` | Merged visible layers export shares drill export path |
| `src/callbacks.c` | `LAYER_SELECTED` → `default` | Resolves selected index then falls to default toggle logic |
| `src/csv.c` (×2) | `ST_START` → `ST_COLLECT` | State-machine transition (char and wchar_t variants) |
| `src/drill.c` | `case 'R':` → `case 'S':` | Repeat-hole command falls through to spindle speed handler |
| `src/main.c` | `case 'w':` → `case 'W':` | Lowercase sets pixel flag then shares window-size parsing |

## Test plan

- [x] Clean build with zero `-Wimplicit-fallthrough` warnings
- [x] 94/104 regression tests pass (same 10 pre-existing rendering mismatches)
- [x] Functional test: `test-amacro-hex-expression.gbx` exports correctly
- [x] Functional test: `test-gerber-x2-attributes.gbx` exports correctly

Closes #287