### PR TITLE
Number of monitors should not affect the start window height.

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1752,7 +1752,7 @@ interface_create_gui (int req_width, int req_height)
 		nmonitors = gdk_screen_get_n_monitors(screen);
 
 		width = gdk_screen_get_width(screen) * 3/4 / nmonitors;
-		height = gdk_screen_get_height(screen) * 3/4 / nmonitors;
+		height = gdk_screen_get_height(screen) * 3/4;
 	}
 
 	gtk_window_set_default_size(GTK_WINDOW(mainWindow), width, height);


### PR DESCRIPTION
Most people who uses several monitors use them side by side. So the window should not be adapted in height. Though I kept the 3/4 of the screen height so there is still some area to grab on to after start and the window popping up does not explode in your face.

Fixes #209 