### PR TITLE
ci: add tag trigger and GitHub Release job

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Security fixes
+      labels: [ security ]
+    - title: Bug fixes
+      labels: [ bug, fix, drill ]
+    - title: New features
+      labels: [ enhancement ]
+    - title: Documentation
+      labels: [ documentation ]
+    - title: Platform support
+      labels: [ Windows, GTK3/GTK4 ]
+    - title: Other changes
+      labels: [ "*" ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - develop
+    tags:
+      - 'v*'
   pull_request:
     branches: [ develop ]
   workflow_dispatch:
@@ -143,3 +145,32 @@ jobs:
       env:
         GERBV_BUILDBOT_PAT: ${{ secrets.GERBV_BUILDBOT_PAT }}
       if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/develop' && env.GERBV_BUILDBOT_PAT && !matrix.code_coverage }}
+
+  release:
+    runs-on: ubuntu-22.04
+    needs: ci
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: gerbv
+          path: artifacts/
+
+      - name: Rename artifacts to use version tag
+        run: |
+          cd artifacts
+          for f in gerbv_*; do
+            os_part=$(echo "$f" | sed 's/gerbv_[0-9-]*_[a-f0-9]*_//')
+            mv "$f" "gerbv_${{ github.ref_name }}_${os_part}"
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
+          generate_release_notes: true


### PR DESCRIPTION
Add 'v*' tag trigger to the push event so version tags run the CI pipeline. Add a release job that depends on ci, downloads the built platform packages, and publishes a GitHub Release via softprops/action-gh-release. Tags containing -rc, -alpha, or -beta are automatically marked as pre-release.

Release notes will be written manually on GitHub after the release job creates the draft. Removes generate_release_notes to leave the description blank for manual editing.

Add release.yml to group auto-generated release notes by existing repo labels: security, bug/fix/drill, enhancement, documentation, Windows/GTK3/GTK4, and a catch-all. Re-enable generate_release_notes in the release job to populate release descriptions automatically.

Add draft: true so the GitHub Release is not immediately public after the build completes. Requires manually clicking Publish on GitHub after reviewing artifacts and writing release notes.

Artifact filenames from the build use date and short commit hash (e.g. gerbv_2025-12-25_45ac82_(Debian 13).deb). Before publishing to a GitHub Release, rename them to use the version tag instead (e.g. gerbv_v2.11.0-rc.1_(Debian 13).deb). CI artifact naming is unchanged.