### PR TITLE
feat: add gerbv_create_excellon_image_from_filename() to public API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 add_library(gerbv SHARED)
 set_target_properties(gerbv PROPERTIES
-                   VERSION 1.9.0
+                   VERSION 1.10.0
                    SOVERSION 1
                    PUBLIC_HEADER gerbv.h)
 target_sources(gerbv PRIVATE

--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -631,6 +631,23 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
 } /* open_image */
 
 gerbv_image_t *
+gerbv_create_excellon_image_from_filename (const gchar *filename)
+{
+    gerbv_image_t *returnImage;
+    gerb_file_t *fd;
+
+    fd = gerb_fopen(filename);
+    if (fd == NULL) {
+        GERB_COMPILE_ERROR(_("Trying to open \"%s\": %s"),
+                filename, strerror(errno));
+        return NULL;
+    }
+    returnImage = parse_drillfile(fd, NULL, 0, 0);
+    gerb_fclose(fd);
+    return returnImage;
+} /* gerbv_create_excellon_image_from_filename */
+
+gerbv_image_t *
 gerbv_create_rs274x_image_from_filename (gchar const* filename){
 	gerbv_image_t *returnImage;
 	gerb_file_t *fd;

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -1002,6 +1002,12 @@ gerbv_export_dxf_file_from_image (const gchar *filename, /*!< the filename for t
 		gerbv_user_transformation_t *transform /*!< the transformation to apply before exporting */
 );
 
+//! Parse an Excellon drill file and return the parsed image
+//! \return the new gerbv_image_t, or NULL if not successful
+gerbv_image_t *
+gerbv_create_excellon_image_from_filename (const gchar *filename /*!< the filename of the file to be parsed*/
+);
+
 //! Parse a RS274X file and return the parsed image
 //! \return the new gerbv_image_t, or NULL if not successful
 gerbv_image_t *


### PR DESCRIPTION
 ## Summary

- Adds `gerbv_create_excellon_image_from_filename()` to the public libgerbv API, the missing counterpart to
`gerbv_create_rs274x_image_from_filename()`
- Allows callers to load Excellon drill files directly without going through the full project machinery
- Based on SourceForge patch #73 and GitHub PR #9

## Files changed

- `src/gerbv.h` — public function declaration
- `src/gerbv.c` — implementation

## Test plan

- [x] Build with `cmake --build build -j$(nproc)` — clean, 0 errors
- [x] Symbol exported: `nm -D libgerbv.so | grep excellon_image_from_filename` — present as global `T`
- [x] Regression tests: 94 pass / 10 fail (all 10 are pre-existing Cairo version mismatches, no new failures)
- [x] API smoke test: loaded `.exc` file, netlist + tools present, destroyed cleanly
