### PR TITLE
cmake: fix tarball builds and generated path handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,12 @@ endif()
 if(Intl_FOUND)
     target_link_libraries(compilation-flags INTERFACE Intl::Intl)
 endif()
+if(APPLE)
+    target_compile_definitions(compilation-flags INTERFACE QUARTZ)
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(compilation-flags INTERFACE _GNU_SOURCE)
+endif()
 
 ## This is installation directory settings. These must be solved later by install target
 target_compile_definitions(compilation-flags INTERFACE "GERBV_DATADIR=\"${DATADIR}\"")

--- a/cmake/GetGitVersion.cmake
+++ b/cmake/GetGitVersion.cmake
@@ -18,6 +18,11 @@ if(__get_git_version)
 endif()
 set(__get_git_version INCLUDED)
 function(get_git_version var)
+  set(FALLBACK_GIT_VERSION "v0.0.0")
+  if(PROJECT_VERSION)
+      set(FALLBACK_GIT_VERSION "v${PROJECT_VERSION}")
+  endif()
+
   if(GIT_EXECUTABLE)
       execute_process(COMMAND ${GIT_EXECUTABLE} describe --tag --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=8
           WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -25,26 +30,27 @@ function(get_git_version var)
           OUTPUT_VARIABLE GIT_VERSION
           ERROR_QUIET)
       if(${status})
-          set(GIT_VERSION "v0.0.0")
+          set(GIT_VERSION "${FALLBACK_GIT_VERSION}")
       else()
           string(STRIP ${GIT_VERSION} GIT_VERSION)
         #   string(REGEX REPLACE "-[0-9]+-g" "-" GIT_VERSION ${GIT_VERSION})
-      endif()
-      # Work out if the repository is dirty
-      execute_process(COMMAND ${GIT_EXECUTABLE} update-index -q --refresh
-          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-          OUTPUT_QUIET
-          ERROR_QUIET)
-      execute_process(COMMAND ${GIT_EXECUTABLE} diff-index --name-only HEAD --
-          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-          OUTPUT_VARIABLE GIT_DIFF_INDEX
-          ERROR_QUIET)
-      string(COMPARE NOTEQUAL "${GIT_DIFF_INDEX}" "" GIT_DIRTY)
-      if (${GIT_DIRTY})
-          set(GIT_VERSION "${GIT_VERSION}-dirty")
+
+          # Work out if the repository is dirty
+          execute_process(COMMAND ${GIT_EXECUTABLE} update-index -q --refresh
+              WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+              OUTPUT_QUIET
+              ERROR_QUIET)
+          execute_process(COMMAND ${GIT_EXECUTABLE} diff-index --name-only HEAD --
+              WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+              OUTPUT_VARIABLE GIT_DIFF_INDEX
+              ERROR_QUIET)
+          string(COMPARE NOTEQUAL "${GIT_DIFF_INDEX}" "" GIT_DIRTY)
+          if (${GIT_DIRTY})
+              set(GIT_VERSION "${GIT_VERSION}-dirty")
+          endif()
       endif()
   else()
-      set(GIT_VERSION "v0.0.0")
+      set(GIT_VERSION "${FALLBACK_GIT_VERSION}")
   endif()
   message("-- git Version: ${GIT_VERSION}")
   set(${var} ${GIT_VERSION} PARENT_SCOPE)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -89,8 +89,6 @@ add_custom_command(
     DEPENDS ${CMAKE_SOURCE_DIR}/BUGS ${CMAKE_SOURCE_DIR}/AUTHORS
     VERBATIM)
 
-add_library(generated INTERFACE)
-target_sources(generated PRIVATE bugs.c authors.c)
-target_include_directories(generated INTERFACE)
+add_custom_target(generated DEPENDS bugs.c authors.c)
 set_target_properties(generated PROPERTIES
                         ADDITIONAL_CLEAN_FILES "bugs.c;authors.c")

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -3,11 +3,12 @@ set(GETTEXT_DOMAIN "gerbv")
 set(GETTEXT_TARGET "gerbv-translations")
 set(GETTEXT_OUTPUT_DIR "locale")
 set(GETTEXT_LANGUAGES "ja" "ru")
+get_filename_component(GERBV_BINARY_DIR "${CMAKE_BINARY_DIR}" ABSOLUTE)
 
 set(GETTEXT_SOURCES
      "../src/attribute.c"
-     ${CMAKE_BINARY_DIR}/config/authors.c
-     ${CMAKE_BINARY_DIR}/config/bugs.c
+     ${GERBV_BINARY_DIR}/config/authors.c
+     ${GERBV_BINARY_DIR}/config/bugs.c
      ../src/callbacks.c
      ../src/csv.c
      ../src/draw-gdk.c
@@ -65,6 +66,7 @@ configure_gettext(
  BUILD_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${GETTEXT_OUTPUT_DIR}
  ALL
 )
+add_dependencies(${GETTEXT_TARGET} generated)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${GETTEXT_OUTPUT_DIR}/ TYPE LOCALE)
 

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,9 +1,4 @@
-
 configure_file(gerbv.1.in ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1 @ONLY)
 
-file(ARCHIVE_CREATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1.gz
-                    PATHS ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1
-                    COMPRESSION GZip )
- 
 cmake_path(SET CMAKE_INSTALL_MANDIR NORMALIZE ${CMAKE_INSTALL_MANDIR}/man1)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1.gz TYPE MAN) # Need processed and compressed
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1 TYPE MAN)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,12 @@ target_sources(gerbv-app PRIVATE
                 lrealpath.c lrealpath.h)
 # target_compile_definitions(gerbv-app PUBLIC GDK_DISABLE_DEPRECATED GTK_DISABLE_DEPRECATED) # Removes all deprecated functions
 target_compile_definitions(gerbv-app PRIVATE $<$<BOOL:${DEBUG_PRINTOUT}>:DEBUG=1>)
-target_link_libraries(gerbv-app PRIVATE gerbv compilation-flags config generated)
+target_link_libraries(gerbv-app PRIVATE gerbv compilation-flags config)
+add_dependencies(gerbv-app generated)
+if(APPLE)
+    set_target_properties(gerbv-app PROPERTIES
+                         INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+endif()
 
 install(TARGETS gerbv-app
         PUBLIC_HEADER


### PR DESCRIPTION
Fix CMake tarball builds used by downstream packaging.

- fall back to `PROJECT_VERSION` when Git metadata is unavailable
- fix generated-source path handling for gettext inputs
- avoid configure-time manpage compression failure by installing the configured manpage directly
- keep Homebrew-specific compile/rpath adjustments in-tree for macOS/Linux

Ref: https://github.com/Homebrew/homebrew-core/pull/269931
