### PR TITLE
Acknowledge machine-only Excellon G/M-codes

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1609,6 +1609,7 @@ callbacks_analyze_active_drill_activate(GtkMenuItem *menuitem,
 	table_add_row(G_table, "G90", stat->G90, _(drill_g_code_name(90)));
 	table_add_row(G_table, "G91", stat->G91, _(drill_g_code_name(91)));
 	table_add_row(G_table, "G93", stat->G93, _(drill_g_code_name(93)));
+	table_add_row(G_table, "", stat->G_machine_only, _("machine-only G-codes (ignored)"));
 	table_add_row(G_table, "", stat->G_unknown, _("unknown G-codes"));
 
 	table_set_sortable(G_table);
@@ -1640,6 +1641,7 @@ callbacks_analyze_active_drill_activate(GtkMenuItem *menuitem,
 	table_add_row(M_table, "M95", stat->M95, _(drill_m_code_name(95)));
 	table_add_row(M_table, "M97", stat->M97, _(drill_m_code_name(97)));
 	table_add_row(M_table, "M98", stat->M98, _(drill_m_code_name(98)));
+	table_add_row(M_table, "", stat->M_machine_only, _("machine-only M-codes (ignored)"));
 	table_add_row(M_table, "", stat->M_unknown, _("unknown M-codes"));
 
 	table_set_sortable(M_table);

--- a/src/drill.c
+++ b/src/drill.c
@@ -628,6 +628,33 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 		g_free(tmps);
 		break;
 
+	    case DRILL_G_OVERRIDETOOLSPEED:        /* G07 */
+	    case DRILL_G_VISTOOL:                  /* G34 */
+	    case DRILL_G_VISSINGLEPOINTOFFSET:     /* G35 */
+	    case DRILL_G_VISMULTIPOINTTRANS:       /* G36 */
+	    case DRILL_G_VISCANCEL:                /* G37 */
+	    case DRILL_G_VISCORRHOLEDRILL:         /* G38 */
+	    case DRILL_G_VISAUTOCALIBRATION:       /* G39 */
+	    case DRILL_G_CUTTERCOMPOFF:            /* G40 */
+	    case DRILL_G_CUTTERCOMPLEFT:           /* G41 */
+	    case DRILL_G_CUTTERCOMPRIGHT:          /* G42 */
+	    case DRILL_G_VISSINGLEPOINTOFFSETREL:  /* G45 */
+	    case DRILL_G_VISMULTIPOINTTRANSREL:    /* G46 */
+	    case DRILL_G_VISCANCELREL:             /* G47 */
+	    case DRILL_G_VISCORRHOLEDRILLREL:      /* G48 */
+	    case DRILL_G_PACKDIP2:                 /* G81 */
+	    case DRILL_G_PACKDIP:                  /* G82 */
+	    case DRILL_G_PACK8PINL:                /* G83 */
+	    case DRILL_G_CIRLE:                    /* G84 */
+		eat_line(fd);
+		gerbv_stats_printf(stats->error_list,
+			GERBV_MESSAGE_NOTE, -1,
+			_("Ignoring machine-only G%02d (%s) "
+			    "at line %u in file \"%s\""),
+			g_code, _(drill_g_code_name(g_code)),
+			file_line, fd->filename);
+		break;
+
 	    default:
 		eat_line(fd);
 		gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_ERROR, -1,
@@ -797,6 +824,25 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 			tmps, file_line, fd->filename);
 		g_free(tmps);
 
+		break;
+
+	    case DRILL_M_STOPOPTIONAL:                    /* M06 */
+	    case DRILL_M_SANDREND:                        /* M08 */
+	    case DRILL_M_STOPINSPECTION:                  /* M09 */
+	    case DRILL_M_VISANDRPATTERN:                  /* M50 */
+	    case DRILL_M_VISANDRPATTERNREWIND:            /* M51 */
+	    case DRILL_M_VISANDRPATTERNOFFSETCOUNTERCTRL: /* M52 */
+	    case DRILL_M_REFSCALING:                      /* M60 */
+	    case DRILL_M_REFSCALINGEND:                   /* M61 */
+	    case DRILL_M_PECKDRILLING:                    /* M62 */
+	    case DRILL_M_PECKDRILLINGEND:                 /* M63 */
+		eat_line(fd);
+		gerbv_stats_printf(stats->error_list,
+			GERBV_MESSAGE_NOTE, -1,
+			_("Ignoring machine-only M%02d (%s) "
+			    "at line %u in file \"%s\""),
+			m_code, _(drill_m_code_name(m_code)),
+			file_line, fd->filename);
 		break;
 
 	    default:
@@ -1487,6 +1533,13 @@ drill_parse_M_code(gerb_file_t *fd, drill_state_t *state,
 	stats->M98++;
 	break;
 
+    case 6:
+    case 8: case 9:
+    case 50: case 51: case 52:
+    case 60: case 61: case 62: case 63:
+	stats->M_machine_only++;
+	break;
+
     default:
     case DRILL_M_UNKNOWN:
 	break;
@@ -1903,6 +1956,14 @@ drill_parse_G_code(gerb_file_t *fd, gerbv_image_t *image, unsigned int file_line
 	break;
     case 93:
 	stats->G93++;
+	break;
+
+    case 7:
+    case 34: case 35: case 36: case 37: case 38: case 39:
+    case 40: case 41: case 42:
+    case 45: case 46: case 47: case 48:
+    case 81: case 82: case 83: case 84:
+	stats->G_machine_only++;
 	break;
 
     case DRILL_G_UNKNOWN:

--- a/src/drill_stats.c
+++ b/src/drill_stats.c
@@ -132,6 +132,7 @@ gerbv_drill_stats_add_layer(gerbv_drill_stats_t *accum_stats,
     accum_stats->G90 += input_stats->G90;
     accum_stats->G91 += input_stats->G91;
     accum_stats->G93 += input_stats->G93;
+    accum_stats->G_machine_only += input_stats->G_machine_only;
     accum_stats->G_unknown += input_stats->G_unknown;
 
     accum_stats->M00 += input_stats->M00;
@@ -148,6 +149,7 @@ gerbv_drill_stats_add_layer(gerbv_drill_stats_t *accum_stats,
     accum_stats->M95 += input_stats->M95;
     accum_stats->M97 += input_stats->M97;
     accum_stats->M98 += input_stats->M98;
+    accum_stats->M_machine_only += input_stats->M_machine_only;
     accum_stats->M_unknown += input_stats->M_unknown;
 
     accum_stats->R += input_stats->R;

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -527,6 +527,7 @@ typedef struct {
     int G90;
     int G91;
     int G93;
+    int G_machine_only;
     int G_unknown;
 
     int M00;
@@ -543,6 +544,7 @@ typedef struct {
     int M95;
     int M97;
     int M98;
+    int M_machine_only;
     int M_unknown;
 
     int R;


### PR DESCRIPTION
## Summary

- Add explicit `case` handlers for 17 G-codes and 10 M-codes that control physical machine behavior (vision systems, cutter compensation, peck drilling, etc.) with no visual representation
- Log at `GERBV_MESSAGE_NOTE` level instead of falling through to `default:` which incorrectly reports them as `GERBV_MESSAGE_ERROR`
- Track under grouped `G_machine_only`/`M_machine_only` stats counters shown in the analysis dialog

### G-codes (17): G07, G34–G39, G40–G42, G45–G48, G81–G84
### M-codes (10): M06, M08, M09, M50–M52, M60–M63

Per-code stats counters are possible if the maintainer or community wants more granularity, but grouped counters keep the struct small for codes that have no visual effect.

Codes with real implementations on other branches (G02/G03 #298, G87 #300, M70/M80/M90 #301, M25/M01/M02 #304) are excluded. M99 (user defined pattern) is also excluded as it may have future implementation potential.

## Test plan

- [x] `cmake --build build` — clean build, zero warnings
- [x] `ctest` — all existing tests pass (94/104, 10 pre-existing image comparison mismatches identical to develop)
- [x] Test `.exc` file with machine-only codes produces NOTE-level messages, not ERROR

Ref: #297