### PR TITLE
feat: warn when loaded file contains no geometry

### DIFF
--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -602,10 +602,10 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
     
     if (parsed_image) {
 	/* Warn if the file parsed successfully but contains no geometry */
-	if (parsed_image->netlist != NULL
-	&&  parsed_image->netlist->next == NULL) {
-	    if (parsed_image->layertype == GERBV_LAYERTYPE_DRILL
-	    &&  parsed_image->drill_stats != NULL) {
+	if ((parsed_image->netlist != NULL)
+	&&  (parsed_image->netlist->next == NULL)) {
+	    if ((parsed_image->layertype == GERBV_LAYERTYPE_DRILL)
+	    &&  (parsed_image->drill_stats != NULL)) {
 		gerbv_stats_printf(
 		    parsed_image->drill_stats->error_list,
 		    GERBV_MESSAGE_WARNING, -1,

--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -62,6 +62,7 @@
 #include "draw.h"
 
 #include "pick-and-place.h"
+#include "gerb_stats.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
 #define dprintf if(DEBUG) printf
@@ -600,6 +601,25 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
     }
     
     if (parsed_image) {
+	/* Warn if the file parsed successfully but contains no geometry */
+	if (parsed_image->netlist != NULL
+	&&  parsed_image->netlist->next == NULL) {
+	    if (parsed_image->layertype == GERBV_LAYERTYPE_DRILL
+	    &&  parsed_image->drill_stats != NULL) {
+		gerbv_stats_printf(
+		    parsed_image->drill_stats->error_list,
+		    GERBV_MESSAGE_WARNING, -1,
+		    _("File \"%s\" contains no drill hits or routes"),
+		    filename);
+	    } else if (parsed_image->gerbv_stats != NULL) {
+		gerbv_stats_printf(
+		    parsed_image->gerbv_stats->error_list,
+		    GERBV_MESSAGE_WARNING, -1,
+		    _("File \"%s\" contains no drawing elements"),
+		    filename);
+	    }
+	}
+
 	/* strip the filename to the base */
 	gchar *baseName = g_path_get_basename (filename);
 	gchar *displayedName;


### PR DESCRIPTION
## Summary

Closes #259.

- Adds a post-parse emptiness check in `gerbv_open_image()` that emits a `GERBV_MESSAGE_WARNING` when a file parses successfully but contains no actual geometry (the net list has only the sentinel node, no real entries)
- Drill files get: `File "..." contains no drill hits or routes` (via `drill_stats->error_list`)
- Gerber files get: `File "..." contains no drawing elements` (via `gerbv_stats->error_list`)
- Single insertion point in `src/gerbv.c`, no changes to parsers

## Test plan

- [x] `cmake --build build` — clean build, zero new warnings
- [x] `ctest` — 94/104 pass (10 pre-existing image mismatches, unchanged)
- [x] `test/inputs/empty.xnc` (existing empty drill file) produces the drill warning
- [x] Minimal empty Gerber file (headers + M02, no draws) produces the Gerber warning
- [x] Non-empty files produce no false positive warnings