### PR TITLE
Fix double rotation of macro circle/line center coordinates (#233)

### DIFF
--- a/src/gerb_image.c
+++ b/src/gerb_image.c
@@ -597,10 +597,6 @@ gerbv_image_copy_all_nets (gerbv_image_t *sourceImage,
 								trans->scaleY;
 					sam->parameter[CIRCLE_ROTATION] +=
 						RAD2DEG(trans->rotation);
-					gerbv_rotate_coord(
-						sam->parameter +CIRCLE_CENTER_X,
-						sam->parameter +CIRCLE_CENTER_Y,
-						trans->rotation);
 
 					if (trans->scaleX != trans->scaleY) {
 						err_scale_circle++;
@@ -698,10 +694,6 @@ gerbv_image_copy_all_nets (gerbv_image_t *sourceImage,
 
 					sam->parameter[LINE21_ROTATION] +=
 						RAD2DEG(trans->rotation);
-					gerbv_rotate_coord(
-						sam->parameter +LINE21_CENTER_X,
-						sam->parameter +LINE21_CENTER_Y,
-						trans->rotation);
 					break;
 
 				case GERBV_APTYPE_MACRO_OUTLINE:


### PR DESCRIPTION
## Summary

- Remove redundant `gerbv_rotate_coord()` calls for CIRCLE, LINE21, and LINE22 macro primitives in `gerb_image.c`
- The rotation parameter update alone is sufficient — `gerbv_rotate_coord()` was double-applying the rotation

## Root cause

The rendering code (`draw.c`) uses `cairo_rotate()` → `cairo_translate()` order for these primitives, so the rotation parameter already rotates the center coordinates as part of the Cairo transformation. The image copy/transform code was additionally pre-rotating the center coordinates via `gerbv_rotate_coord()`, causing a double rotation when the exported file was re-loaded.

LINE20, POLYGON, MOIRE, and THERMAL already handle this correctly — they only update the rotation parameter without calling `gerbv_rotate_coord()`. This fix makes CIRCLE, LINE21, and LINE22 consistent.

## Test plan

- [x] Clean build with zero warnings
- [x] 94/104 regression tests pass (10 pre-existing rendering mismatches)
- [ ] Load a gerber with macro line/circle primitives, rotate, export to RS274X, re-load — verify no double rotation

Fixes #233