### PR TITLE
Added label buildsystem for future release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,6 +8,8 @@ changelog:
       labels: [ enhancement ]
     - title: Documentation
       labels: [ documentation ]
+    - title: Buildsystem (CMake/CTest/CPack/etc)
+      labels: [ buildsystem ]
     - title: Platform support
       labels: [ Windows, GTK3/GTK4 ]
     - title: Other changes


### PR DESCRIPTION
Matching label is added on the GitHub page to be able to tag PRs properly. GitHub can help building release notes if all PRs have a label attached.