### PR TITLE
Guard INCH/METRIC unit assignment with autod in drill header parsing (#241)

### DIFF
--- a/src/drill.c
+++ b/src/drill.c
@@ -1649,7 +1649,9 @@ header_junk:
 	}
     }
 
-    state->unit = GERBV_UNIT_MM;
+    if (state->autod) {
+        state->unit = GERBV_UNIT_MM;
+    }
 
     return 1;
 } /* drill_parse_header_is_metric() */
@@ -1805,7 +1807,9 @@ drill_parse_header_is_inch(gerb_file_t *fd, drill_state_t *state,
 	}
     }
 
-    state->unit = GERBV_UNIT_INCH;
+    if (state->autod) {
+        state->unit = GERBV_UNIT_INCH;
+    }
 
     return 1;
 } /* drill_parse_header_is_inch() */


### PR DESCRIPTION
## Summary

- Guard `state->unit` assignments in `drill_parse_header_is_inch()` and `drill_parse_header_is_metric()` with `if (state->autod)`
- Prevents header INCH/METRIC commands from overwriting user-supplied unit settings when autodetect is disabled

## Root cause

The M-code handlers (`DRILL_M_IMPERIAL`, `DRILL_M_METRIC`) already guard their unit assignments with `if (state->autod)`, but the header parsing functions `drill_parse_header_is_inch()` and `drill_parse_header_is_metric()` set `state->unit` unconditionally. When a user disables autodetect and manually sets the unit (e.g. METRIC), parsing an `INCH` header command overwrites that setting.

## Test plan

- [x] Clean build with zero warnings
- [x] 93/104 regression tests pass (11 pre-existing mismatches, no regression)

Fixes #241