### PR TITLE
Allow static library builds via BUILD_SHARED_LIBS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Building the library, installed as libgerbv.
 # The naming convention is to avoid name clashing in targets
 
-add_library(gerbv SHARED)
+add_library(gerbv)
 set_target_properties(gerbv PROPERTIES
                    VERSION 1.9.0
                    SOVERSION 1


### PR DESCRIPTION
## Summary

- Remove explicit `SHARED` keyword from `add_library(gerbv)` in `src/CMakeLists.txt`
- CMake's built-in `BUILD_SHARED_LIBS` variable now controls the library type
- Default behavior is unchanged (shared library)
- Users can pass `-DBUILD_SHARED_LIBS=OFF` for static builds

## Details

This is the standard CMake idiom for letting users choose between shared and static libraries. The name-clash concern raised in #272 is already solved — the app target is `gerbv-app` (with `OUTPUT_NAME gerbv`), and the library target is `gerbv`, so there's no conflict regardless of library type.

### Usage

```bash
cmake -B build                          # Default: shared (unchanged)
cmake -B build -DBUILD_SHARED_LIBS=OFF  # Static: produces libgerbv.a
```

## Test plan

- [ ] Default build still produces shared library (`libgerbv.so`)
- [ ] `-DBUILD_SHARED_LIBS=OFF` produces static library (`libgerbv.a`)
- [ ] Application links correctly against both shared and static library
- [ ] Existing tests pass

Closes #272