### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: spe-ciellt


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` with `github: spe-ciellt` to enable the **Sponsor** button on the repository
- Addresses point 6 of #169 (donation page for developers)

## Note for @spe-ciellt

For the Sponsor button to become functional, you'll need to enable GitHub Sponsors on your account at https://github.com/sponsors. Once enabled, visitors will see a "Sponsor" button on the repository linking to your profile.

[Source Parts Inc.](https://source.parts) would like the option of sponsoring and supporting gerbv — enabling Sponsors would make that possible.

GitHub also supports other funding platforms in `FUNDING.yml` if you'd prefer an alternative to GitHub Sponsors — for example `ko_fi`, `patreon`, `open_collective`, `buy_me_a_coffee`, `liberapay`, or a custom URL. See the [full list of supported platforms](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository). Happy to update the file if you'd like a different option.

## Verification

- [ ] `.github/FUNDING.yml` exists with `github: spe-ciellt`
- [ ] Sponsor button appears on repo (after Stefan enables Sponsors)