### PR TITLE
Fix non-ASCII file path handling on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 ## Glib-2.0 and GTK-2.0
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-2.0)
-pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0>=2.6)
 
 ## DXF support library
 pkg_check_modules(DXF IMPORTED_TARGET dxflib)

--- a/src/interface.c
+++ b/src/interface.c
@@ -71,7 +71,7 @@ rename_main_window(char const* filename, GtkWidget *main_win)
 	g_assert(win != NULL);
 
 	if (filename && filename[0] != '\0') {
-		gchar *basename = g_path_get_basename(filename);
+		gchar *basename = g_filename_display_basename(filename);
 		g_string_printf(win_title, "%s — Gerbv", basename);
 		g_free(basename);
 	} else {

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,8 @@
 # include <getopt.h>
 #endif
 
+#include <glib/gstdio.h>
+
 #include "common.h"
 #include "main.h"
 #include "callbacks.h"
@@ -506,6 +508,16 @@ main(int argc, char *argv[])
 #endif
 
     attach_console_for_win();
+
+#ifdef G_OS_WIN32
+    /* Convert argv from system codepage to UTF-8 for GLib functions */
+    for (i = 0; i < argc; i++) {
+        gchar *utf8_arg = g_locale_to_utf8(argv[i], -1, NULL, NULL, NULL);
+        if (utf8_arg) {
+            argv[i] = utf8_arg;
+        }
+    }
+#endif
 
     /*
      * Setup the screen info. Must do this before getopt, since getopt

--- a/src/project.c
+++ b/src/project.c
@@ -58,6 +58,8 @@
 #include <errno.h>
 #include <math.h>
 
+#include <glib/gstdio.h>
+
 #include "common.h"
 #include "gerbv.h"
 #include "gerb_file.h"
@@ -907,7 +909,7 @@ project_is_gerbv_project(const char *filename, gboolean *ret)
 	char *buf;
 	const gsize buf_size = 200;
 
-	fd = fopen(filename, "rb");
+	fd = g_fopen(filename, "rb");
 	if (fd == NULL) {
 		GERB_MESSAGE(_("Failed to open \"%s\" for reading: %s"),
 				filename, strerror(errno));
@@ -1005,7 +1007,7 @@ read_project_file(char const* filename)
     }
     dprintf("%s():  initfile = \"%s\"\n", __FUNCTION__, initfile);
 
-    if ((fd = fopen(initfile, "r")) == NULL) {
+    if ((fd = g_fopen(initfile, "r")) == NULL) {
 	scheme_deinit(sc);
 	GERB_MESSAGE(_("Couldn't open %s (%s)"), initfile, strerror(errno));
 	return NULL;
@@ -1029,7 +1031,7 @@ read_project_file(char const* filename)
 			    sc->vptr->mk_symbol(sc, "gerbv-file-version!"),
 			    sc->vptr->mk_foreign_func(sc, gerbv_file_version));
 
-    if ((fd = fopen(filename, "r")) == NULL) {
+    if ((fd = g_fopen(filename, "r")) == NULL) {
 	setlocale(LC_NUMERIC, "");	/* Default locale */
 	scheme_deinit(sc);
 	GERB_MESSAGE(_("Couldn't open project file %s (%s)"), filename,
@@ -1078,7 +1080,7 @@ write_project_file(gerbv_project_t *gerbvProject, char const* filename, project_
     const float min_val = GERBV_PRECISION_LINEAR_INCH;
     int i;
 
-    if ((fd = fopen(filename, "w")) == NULL) {
+    if ((fd = g_fopen(filename, "w")) == NULL) {
 	    GERB_MESSAGE(_("Couldn't save project %s"), filename);
 	    return -1;
     }

--- a/src/tooltable.c
+++ b/src/tooltable.c
@@ -29,6 +29,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <glib/gstdio.h>
+
 #include "common.h"
 #include "gerbv.h"
 
@@ -130,7 +132,7 @@ gerbv_process_tools_file(const char *tf)
     if (tf == NULL)
         return 0;
     
-    f = fopen(tf, "r");
+    f = g_fopen(tf, "r");
     if (f == NULL) {
         GERB_COMPILE_ERROR(_("Failed to open \"%s\" for reading"), tf);
         return 0;


### PR DESCRIPTION
## Summary

Tier 1 fix for non-ASCII file path handling on Windows.

- Replace `fopen()` with `g_fopen()` in `project.c` (4 calls) and `tooltable.c` (1 call) so that files with non-ASCII characters in their paths (e.g. `ö`, `ü`, CJK) open correctly on Windows
- Convert `argv` from system codepage to UTF-8 via `g_locale_to_utf8()` on Windows so CLI-supplied paths work with GLib file functions
- Use `g_filename_display_basename()` instead of `g_path_get_basename()` for the window title so non-ASCII basenames render properly
- Set explicit `glib-2.0>=2.6` minimum in CMakeLists.txt to document the dependency on `g_fopen()` and `g_filename_display_basename()`

Closes #234

## Details

On Windows, `fopen()` interprets filenames using the system codepage (e.g. Windows-1252), which cannot represent characters outside that codepage. GLib's `g_fopen()` internally converts UTF-8 paths to wide-char via `_wfopen()`, handling all Unicode filenames correctly.

Similarly, `argv` on Windows is encoded in the system codepage. Since GLib functions expect UTF-8, the fix converts each `argv` entry via `g_locale_to_utf8()` early in `main()`. This uses the conservative `g_locale_to_utf8()` (available in all GLib 2.x) rather than `g_win32_get_command_line()` (which requires GLib 2.40+).

## Scope

This is a tier 1 fix covering the straightforward cases. Not touched (separate work):
- `export-image.c` — would need a stream API refactor
- `scheme.c` — embedded TinyScheme interpreter
- `lrealpath.c` — Win32 path canonicalization
- dxflib DXF export — third-party library

## Test plan

- [ ] Linux: verify files with UTF-8 names (e.g. `Löten.gbr`) open as before
- [ ] Windows: open files with non-ASCII paths from both CLI and GUI file dialog
- [ ] Existing test suite passes (94/104 pass; 10 are pre-existing image comparison mismatches)