### PR TITLE
Fix errno clobbered by cleanup in gerb_fopen()

### DIFF
--- a/src/gerb_file.c
+++ b/src/gerb_file.c
@@ -69,7 +69,9 @@ gerb_fopen(char const * filename)
     /* fopen() can't open files with non ASCII filenames on windows */
     fd->fd = g_fopen(filename, "rb");
     if (fd->fd == NULL) {
+	int saved_errno = errno;
 	g_free(fd);
+	errno = saved_errno;
 	return NULL;
     }
 
@@ -77,8 +79,10 @@ gerb_fopen(char const * filename)
     fd->ptr = 0;
     fd->fileno = fileno(fd->fd);
     if (fstat(fd->fileno, &statinfo) < 0) {
+	int saved_errno = errno;
 	fclose(fd->fd);
 	g_free(fd);
+	errno = saved_errno;
 	return NULL;
     }
 
@@ -105,18 +109,22 @@ gerb_fopen(char const * filename)
     fd->data = (char *)mmap(0, statinfo.st_size, PROT_READ, MAP_PRIVATE,
 			    fd->fileno, 0);
     if(fd->data == MAP_FAILED) {
+	int saved_errno = errno;
 	fclose(fd->fd);
 	g_free(fd);
-	fd = NULL;
+	errno = saved_errno;
+	return NULL;
     } else {
 	/* Copy into a heap buffer with null terminator so strtol/strtod
 	 * have a safe stopping point — mmap does not guarantee '\0'
 	 * after the file content. */
 	char *buf = (char *)g_malloc(fd->datalen + 1);
 	if (buf == NULL) {
+	    int saved_errno = errno;
 	    munmap(fd->data, fd->datalen);
 	    fclose(fd->fd);
 	    g_free(fd);
+	    errno = saved_errno;
 	    return NULL;
 	}
 	memcpy(buf, fd->data, fd->datalen);
@@ -132,14 +140,18 @@ gerb_fopen(char const * filename)
     fd->datalen = (int)statinfo.st_size;
     fd->data = calloc(1, statinfo.st_size + 1);
     if (fd->data == NULL) {
+	int saved_errno = errno;
         fclose(fd->fd);
         g_free(fd);
+	errno = saved_errno;
         return NULL;
     }
     if (fread((void*)fd->data, 1, statinfo.st_size, fd->fd) != statinfo.st_size) {
+	int saved_errno = errno;
         fclose(fd->fd);
 	g_free(fd->data);
         g_free(fd);
+	errno = saved_errno;
 	return NULL;
     }
     rewind (fd->fd);


### PR DESCRIPTION
## Summary

- Preserve `errno` across cleanup calls (`fclose`, `g_free`, `munmap`) in all error paths of `gerb_fopen()`
- Fix a latent NULL pointer dereference on the `mmap` failure path

Found while reviewing #302 — the `strerror(errno)` pattern used by all three callers (`gerbv_open_image`, `gerbv_create_rs274x_image_from_filename`, `gerbv_create_excellon_image_from_filename`) relies on `gerb_fopen()` preserving `errno`, but the cleanup calls before `return NULL` could clobber it.

## Details

`gerb_fopen()` has six error return paths after the initial allocation. In each case, cleanup functions (`fclose()`, `g_free()`, `munmap()`) run between the failing call and `return NULL`. These cleanup functions are allowed to modify `errno`, so callers that use `strerror(errno)` may get an unrelated error message.

The fix uses the standard POSIX `saved_errno` idiom — save `errno` immediately after the failing call, perform cleanup, then restore it before returning. This is the established pattern in GLib/POSIX C code (used throughout glibc internals, libgit2, curl, and GLib itself) for any wrapper function that performs cleanup between a failing syscall and its return.

Additionally, the `mmap` failure path previously set `fd = NULL` and fell through to `fd->filename = g_strdup(...)`, which would dereference NULL. This is now a proper `return NULL`.

## Affected error paths

| Failing call | Cleanup before return | errno preserved |
|---|---|---|
| `g_fopen()` | `g_free()` | now yes |
| `fstat()` | `fclose()`, `g_free()` | now yes |
| `mmap()` | `fclose()`, `g_free()` | now yes (+ now returns NULL) |
| `g_malloc()` | `munmap()`, `fclose()`, `g_free()` | now yes |
| `calloc()` | `fclose()`, `g_free()` | now yes |
| `fread()` | `fclose()`, `g_free()` x2 | now yes |

## Test plan

- [x] Clean build, zero warnings
- [x] 94/104 regression tests pass (10 pre-existing image comparison mismatches)

Ref: #302