### PR TITLE
fix: replace unsafe dprintf macro with safe DPRINTF variadic macro

### DIFF
--- a/src/attribute.c
+++ b/src/attribute.c
@@ -51,7 +51,7 @@
 #include "attribute.h"
 #include "main.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static int auto_uncheck_needed = 0;
 static GtkWidget * auto_uncheck_widget = NULL;
@@ -306,7 +306,7 @@ attribute_interface_dialog (gerbv_HID_Attribute * attrs,
     exit (1);
   }
 
-  dprintf ("%s(%p, %d, %p, \"%s\", \"%s\")\n", __FUNCTION__, attrs, n_attrs, results, title, descr);
+  DPRINTF("%s(%p, %d, %p, \"%s\", \"%s\")\n", __FUNCTION__, attrs, n_attrs, results, title, descr);
 
   auto_uncheck_needed = 0;
   auto_uncheck_widget = NULL;
@@ -338,7 +338,7 @@ attribute_interface_dialog (gerbv_HID_Attribute * attrs,
    */
   for (j = 0; j < n_attrs; j++)
       {
-	  dprintf ("%s(): adding attribute #%d\n", __func__, j);
+	  DPRINTF("%s(): adding attribute #%d\n", __func__, j);
 	  switch (attrs[j].type)
 	      {
 	      case HID_Label:
@@ -486,7 +486,7 @@ attribute_interface_dialog (gerbv_HID_Attribute * attrs,
 		  break;
 
 	      case HID_Mixed:
-		  dprintf ("HID_Mixed\n");
+		  DPRINTF("HID_Mixed\n");
 		  break;
 
 	      case HID_Path:

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -73,7 +73,7 @@
 #endif
 
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /* This default extension should really not be changed, but if it absolutely
  * must change, the ../win32/gerbv.nsi.in *must* be changed to reflect that.
@@ -458,12 +458,12 @@ gerbv_image_t *merge_images (int type)
 		GERB_COMPILE_ERROR(_("Unknown Layer type for merge"));
 		goto err;
 	}
-	dprintf("Looking for matching files\n");
+	DPRINTF("Looking for matching files\n");
 	for (i = img = filecount = 0; i < mainProject->max_files; ++i) {
 		if (mainProject->file[i] &&  mainProject->file[i]->isVisible &&
 		(mainProject->file[i]->image->layertype == layertype)) {
 			++filecount;
-			dprintf("Adding '%s'\n", mainProject->file[i]->name);
+			DPRINTF("Adding '%s'\n", mainProject->file[i]->name);
 			images[img].image=mainProject->file[i]->image;
 			images[img++].transform=&mainProject->file[i]->transform;
 			images = (struct l_image_info *)g_renew(struct l_image_info, images, img+1);
@@ -473,7 +473,7 @@ gerbv_image_t *merge_images (int type)
 		GERB_COMPILE_ERROR(_("Not Enough Files of same type to merge"));
 		goto err;
 	}
-	dprintf("Now merging files\n");
+	DPRINTF("Now merging files\n");
 	for (i = 0; i < img; ++i) {
 		gerbv_user_transformation_t *thisTransform;
 		gerbv_user_transformation_t identityTransform = {0,0,1,1,0,FALSE,FALSE,FALSE};
@@ -2040,7 +2040,7 @@ callbacks_render_type_changed () {
 	isChanging = TRUE;
 	gerbv_render_types_t type = screenRenderInfo.renderType;
 	GtkCheckMenuItem *check_item = screen.win.menu_view_render_group[type];
-	dprintf ("%s():  type = %d, check_item = %p\n", __FUNCTION__, type, check_item);
+	DPRINTF("%s():  type = %d, check_item = %p\n", __FUNCTION__, type, check_item);
 	gtk_check_menu_item_set_active (check_item, TRUE);
 	gtk_combo_box_set_active (screen.win.sidepaneRenderComboBox, type);
 
@@ -2697,7 +2697,7 @@ callbacks_change_layer_format_clicked  (GtkButton *button, gpointer   user_data)
 		show_no_layers_warning ();
 		return;
 	}
-    dprintf ("%s(): index = %d\n", __FUNCTION__, index);
+    DPRINTF("%s(): index = %d\n", __FUNCTION__, index);
     attr = mainProject->file[index]->image->info->attr_list;
     n =  mainProject->file[index]->image->info->n_attr;
     type =  mainProject->file[index]->image->info->type;
@@ -2713,7 +2713,7 @@ callbacks_change_layer_format_clicked  (GtkButton *button, gpointer   user_data)
 	  return;
 	}
 
-    dprintf ("%s(): n = %d, attr = %p\n", __FUNCTION__, n, attr);
+    DPRINTF("%s(): n = %d, attr = %p\n", __FUNCTION__, n, attr);
     if (n > 0)
 	{
 	    if (mainProject->file[index]->layer_dirty) {
@@ -2741,7 +2741,7 @@ callbacks_change_layer_format_clicked  (GtkButton *button, gpointer   user_data)
           
     }
 
-    dprintf ("%s(): reloading layer\n", __func__);
+    DPRINTF("%s(): reloading layer\n", __func__);
     gerbv_revert_file (mainProject, index);
 
     for (i = 0; i < n; i++)
@@ -3066,10 +3066,10 @@ callbacks_support_benchmark (gerbv_render_info_t *renderInfo) {
 	now = start;
 	while( now - 30 < start) {
 		i++;
-		dprintf("Benchmark():  Starting redraw #%d\n", i);
+		DPRINTF("Benchmark():  Starting redraw #%d\n", i);
 		gerbv_render_to_pixmap_using_gdk (mainProject, renderedPixmap, renderInfo, NULL, NULL);
 		now = time(NULL);
-		dprintf("Elapsed time = %ld seconds\n", (long int) (now - start));
+		DPRINTF("Elapsed time = %ld seconds\n", (long int) (now - start));
 	}
 	g_message(_("FAST (=GDK) mode benchmark: %d redraws "
 				"in %ld seconds (%g redraws/second)"),
@@ -3083,7 +3083,7 @@ callbacks_support_benchmark (gerbv_render_info_t *renderInfo) {
 	renderInfo->renderType = GERBV_RENDER_TYPE_CAIRO_NORMAL;
 	while( now - 30 < start) {
 		i++;
-		dprintf("Benchmark():  Starting redraw #%d\n", i);
+		DPRINTF("Benchmark():  Starting redraw #%d\n", i);
 		cairo_surface_t *cSurface = cairo_image_surface_create  (CAIRO_FORMAT_ARGB32,
 	                              renderInfo->displayWidth, renderInfo->displayHeight);
 		cairo_t *cairoTarget = cairo_create (cSurface);
@@ -3091,7 +3091,7 @@ callbacks_support_benchmark (gerbv_render_info_t *renderInfo) {
 		cairo_destroy (cairoTarget);
 		cairo_surface_destroy (cSurface);
 		now = time(NULL);
-		dprintf("Elapsed time = %ld seconds\n", (long int) (now - start));
+		DPRINTF("Elapsed time = %ld seconds\n", (long int) (now - start));
 	}
 	g_message(_("NORMAL (=Cairo) mode benchmark: %d redraws "
 				"in %ld seconds (%g redraws/second)"),
@@ -3928,7 +3928,7 @@ void
 callbacks_sidepane_render_type_combo_box_changed (GtkComboBox *widget, gpointer user_data) {
 	gerbv_render_types_t type = gtk_combo_box_get_active (widget);
 	
-	dprintf ("%s():  type = %d\n", __FUNCTION__, type);
+	DPRINTF("%s():  type = %d\n", __FUNCTION__, type);
 
 	if (type < 0 || type == screenRenderInfo.renderType)
 		return;
@@ -3945,7 +3945,7 @@ callbacks_viewmenu_rendertype_changed (GtkCheckMenuItem *widget, gpointer user_d
 	if (type == screenRenderInfo.renderType)
 		return;
 
-	dprintf ("%s():  type = %d\n", __FUNCTION__, type);
+	DPRINTF("%s():  type = %d\n", __FUNCTION__, type);
 
 	screenRenderInfo.renderType = type;
 	callbacks_render_type_changed ();
@@ -3959,7 +3959,7 @@ callbacks_viewmenu_units_changed (GtkCheckMenuItem *widget, gpointer user_data) 
 	if (unit < 0 || unit == screen.unit)
 		return;
 
-	dprintf ("%s():  unit = %d, screen.unit = %d\n", __FUNCTION__, unit, screen.unit);
+	DPRINTF("%s():  unit = %d, screen.unit = %d\n", __FUNCTION__, unit, screen.unit);
 
 	callbacks_units_changed (unit);
 }

--- a/src/draw-gdk.c
+++ b/src/draw-gdk.c
@@ -46,7 +46,7 @@
 #undef round
 #define round(x) ceil((double)(x))
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /*
  * If you want to rotate a
@@ -579,14 +579,14 @@ gerbv_gdk_draw_amacro(GdkPixmap *pixmap, GdkGC *gc,
 		      gerbv_simplified_amacro_t *s, double scale, 
 		      gint x, gint y)
 {
-	dprintf("%s(): drawing simplified aperture macros:\n", __func__);
+	DPRINTF("%s(): drawing simplified aperture macros:\n", __func__);
 
 	while (s != NULL) {
 		if (s->type >= GERBV_APTYPE_MACRO_CIRCLE
 		 && s->type <= GERBV_APTYPE_MACRO_LINE22) {
 			dgk_draw_amacro_funcs[s->type](pixmap, gc,
 					s, scale, x, y);
-			dprintf("  %s\n", gerbv_aperture_type_name(s->type));
+			DPRINTF("  %s\n", gerbv_aperture_type_name(s->type));
 		} else {
 			GERB_FATAL_ERROR(
 				_("Unknown simplified aperture macro type %d"),

--- a/src/draw.c
+++ b/src/draw.c
@@ -39,7 +39,7 @@
 #include "common.h"
 #include "selection.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static gboolean draw_do_vector_export_fix(cairo_t *cairoTarget,
 		double *bg_red, double *bg_green, double *bg_blue);
@@ -367,7 +367,7 @@ gerbv_draw_amacro(cairo_t *cairoTarget, cairo_operator_t clearOperator,
 	double bg_r, bg_g, bg_b; /* Background color */
 	int ret = 1;
 
-	dprintf("Drawing simplified aperture macros:\n");
+	DPRINTF("Drawing simplified aperture macros:\n");
 
 	doVectorExportFix =
 		draw_do_vector_export_fix (cairoTarget, &bg_r, &bg_g, &bg_b);
@@ -399,7 +399,7 @@ gerbv_draw_amacro(cairo_t *cairoTarget, cairo_operator_t clearOperator,
 		cairo_save (cairoTarget);
 		cairo_new_path(cairoTarget);
 
-		dprintf("\t%s(): drawing %s\n", __FUNCTION__,
+		DPRINTF("\t%s(): drawing %s\n", __FUNCTION__,
 				gerbv_aperture_type_name(ls->type));
 
 		switch (ls->type) {

--- a/src/drill.c
+++ b/src/drill.c
@@ -56,7 +56,7 @@
 #include "drill_stats.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define MAXL 200
 #define DRILL_READ_DOUBLE_SIZE 32
@@ -255,9 +255,10 @@ drill_add_drill_hole (gerbv_image_t *image, drill_state_t *state,
 	    state->current_tool);
 
     curr_net->next = g_new0(gerbv_net_t, 1);
-    if (curr_net->next == NULL)
+    if (curr_net->next == NULL) {
 	GERB_FATAL_ERROR("malloc curr_net->next failed in %s()",
 			__FUNCTION__);
+    }
 
     curr_net = curr_net->next;
     curr_net->layer = image->layers;
@@ -281,8 +282,9 @@ drill_add_drill_hole (gerbv_image_t *image, drill_state_t *state,
 
     /* Check if aperture is set. Ignore the below instead of
        causing SEGV... */
-    if(image->aperture[state->current_tool] == NULL)
+    if(image->aperture[state->current_tool] == NULL) {
 	return curr_net;
+    }
 
     bbox = &curr_net->boundingBox;
     r = image->aperture[state->current_tool]->parameter[0] / 2;
@@ -313,9 +315,10 @@ drill_add_route_segment(gerbv_image_t *image, drill_state_t *state,
     double start_x, start_y, stop_x, stop_y;
 
     curr_net->next = g_new0(gerbv_net_t, 1);
-    if (curr_net->next == NULL)
+    if (curr_net->next == NULL) {
 	GERB_FATAL_ERROR("malloc curr_net->next failed in %s()",
 			__FUNCTION__);
+    }
 
     curr_net = curr_net->next;
     curr_net->layer = image->layers;
@@ -345,8 +348,9 @@ drill_add_route_segment(gerbv_image_t *image, drill_state_t *state,
 
     /* Check if aperture is set. Ignore the below instead of
        causing SEGV... */
-    if (image->aperture[state->current_tool] == NULL)
+    if (image->aperture[state->current_tool] == NULL) {
 	return curr_net;
+    }
 
     bbox = &curr_net->boundingBox;
     r = image->aperture[state->current_tool]->parameter[0] / 2;
@@ -371,6 +375,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
     gerbv_net_t *curr_net = NULL;
     gerbv_HID_Attribute *hid_attrs;
     int read;
+    gboolean parsing_done = FALSE;
     gerbv_drill_stats_t *stats;
     gchar *tmps;
     unsigned int file_line = 1;
@@ -383,11 +388,12 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
     setlocale(LC_NUMERIC, "C" );
 
     /* Create new image for this layer */
-    dprintf("In parse_drillfile, about to create image for this layer\n");
+    DPRINTF("In parse_drillfile, about to create image for this layer\n");
 
     image = gerbv_create_image(image, "Excellon Drill File");
-    if (image == NULL)
+    if (image == NULL) {
 	GERB_FATAL_ERROR("malloc image failed in %s()", __FUNCTION__);
+    }
 
     if (reload && attr_list != NULL) {
       /* FIXME there should probably just be a function to copy an
@@ -414,18 +420,21 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
     curr_net->state = image->states;
     image->layertype = GERBV_LAYERTYPE_DRILL;
     stats = gerbv_drill_stats_new();
-    if (stats == NULL)
+    if (stats == NULL) {
 	GERB_FATAL_ERROR("malloc stats failed in %s()", __FUNCTION__);
+    }
     image->drill_stats = stats;
 
     /* Create local state variable to track photoplotter state */
     state = new_state(state);
-    if (state == NULL)
+    if (state == NULL) {
 	GERB_FATAL_ERROR("malloc state failed in %s()", __FUNCTION__);
+    }
 
     image->format = g_new0(gerbv_format_t, 1);
-    if (image->format == NULL)
+    if (image->format == NULL) {
 	GERB_FATAL_ERROR("malloc format failed in %s()", __FUNCTION__);
+    }
 
     image->format->omit_zeros = GERBV_OMIT_ZEROS_UNSPECIFIED;
 
@@ -436,8 +445,9 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	state->number_format = FMT_USER;
 	state->decimals = hid_attrs[HA_digits].default_val.int_value;
 
-	if (GERBV_UNIT_MM == hid_attrs[HA_xy_units].default_val.int_value)
+	if (GERBV_UNIT_MM == hid_attrs[HA_xy_units].default_val.int_value) {
 	    state->unit = GERBV_UNIT_MM;
+	}
 
 	switch (hid_attrs[HA_suppression].default_val.int_value) {
 	case SUP_LEAD:
@@ -454,10 +464,10 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	}
     }
 
-    dprintf("%s():  Starting parsing of drill file \"%s\"\n",
+    DPRINTF("%s():  Starting parsing of drill file \"%s\"\n",
 		    __FUNCTION__, fd->filename);
 
-    while ((read = gerb_fgetc(fd)) != EOF) {
+    while (!parsing_done && (read = gerb_fgetc(fd)) != EOF) {
 
 	switch ((char) read) {
 
@@ -470,7 +480,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	    gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_NOTE, -1,
 		    _("Comment \"%s\" at line %u in file \"%s\""),
 		    tmps, file_line, fd->filename);
-	    dprintf("    Comment with ';' \"%s\" at line %u\n",
+	    DPRINTF("    Comment with ';' \"%s\" at line %u\n",
 		    tmps, file_line);
 	    g_free(tmps);
 	    break;
@@ -482,10 +492,11 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 		strcmp (tmps, "DETECT,OFF") == 0) {
 		gchar *tmps2;
 		gchar *tmps3;
-		if (strcmp (tmps, "DETECT,ON") == 0)
+		if (strcmp (tmps, "DETECT,ON") == 0) {
 		    tmps3 = "ON";
-		else
+		} else {
 		    tmps3 = "OFF";
+		}
 
 		/* broken tool detect on/off.  Silently ignored. */
 		if (stats->detect) {
@@ -644,11 +655,13 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	case 'I':
 	    gerb_ungetc(fd); /* To compare full string in function or
 				report full string  */
-	    if (drill_parse_header_is_inch(fd, state, image, file_line))
+	    if (drill_parse_header_is_inch(fd, state, image, file_line)) {
 		break;
+	    }
 
-	    if (drill_parse_header_is_ici(fd, state, image, file_line))
+	    if (drill_parse_header_is_ici(fd, state, image, file_line)) {
 		break;
+	    }
 
 	    tmps = get_line(fd);
 	    gerbv_stats_printf(stats->error_list,
@@ -734,9 +747,10 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 		break;
 	    case DRILL_M_IMPERIAL :
 		if (state->autod) {
-		    if (state->number_format != FMT_00_0000)
+		    if (state->number_format != FMT_00_0000) {
 			/* save metric format definition for later */
 			state->backup_number_format = state->number_format;
+		    }
 		    state->number_format = FMT_00_0000;
 		    state->decimals = 4;
 		    state->unit = GERBV_UNIT_INCH;
@@ -777,16 +791,19 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	    case DRILL_M_END :
 		/* M00 has optional arguments */
 		eat_line(fd);
+		/* M00 ends the program the same way as M30 */
+		[[fallthrough]];
 
 	    case DRILL_M_ENDREWIND :
-		goto drill_parse_end;
+		parsing_done = TRUE;
 		break;
 
 	    case DRILL_M_UNKNOWN:
 		gerb_ungetc(fd); /* To compare full string in function or
 				    report full string  */
-		if (drill_parse_header_is_metric(fd, state, image, file_line))
+		if (drill_parse_header_is_metric(fd, state, image, file_line)) {
 		    break;
+		}
 
 		stats->M_unknown++;
 		tmps = get_line(fd);
@@ -847,7 +864,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 		rcnt = 10*rcnt + (c - '0');
 		c = gerb_fgetc (fd);
 	      }
-	      dprintf ("working on R code (repeat) with a number of reps equal to %d\n", rcnt);
+	      DPRINTF("working on R code (repeat) with a number of reps equal to %d\n", rcnt);
 
 	      step_x = 0.0;
 	      if (c == 'X') {
@@ -862,13 +879,13 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 		gerb_ungetc (fd);
 	      }
 	      
-	      dprintf ("Getting ready to repeat the drill %d times with delta_x = %g, delta_y = %g\n", rcnt, step_x, step_y);
+	      DPRINTF("Getting ready to repeat the drill %d times with delta_x = %g, delta_y = %g\n", rcnt, step_x, step_y);
 
 	      /* spit out the drills */
 	      for (c = 1 ; c <= rcnt ; c++) {
 		state->curr_x = start_x + c*step_x;
 		state->curr_y = start_y + c*step_y;
-		dprintf ("    Repeat #%d - new location is (%g, %g)\n", c, state->curr_x, state->curr_y);
+		DPRINTF("    Repeat #%d - new location is (%g, %g)\n", c, state->curr_x, state->curr_y);
 		curr_net = drill_add_drill_hole (image, state, stats, curr_net);
 	      }
 	      
@@ -935,8 +952,9 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 
 	    /* Get <CR> char, if any, from <LF><CR> pair */
 	    read = gerb_fgetc(fd);
-	    if (read != '\r' && read != EOF)
+	    if (read != '\r' && read != EOF) {
 		    gerb_ungetc(fd);
+	    }
 	    break;
 
 	case '\r' :
@@ -944,8 +962,9 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 
 	    /* Get <LF> char, if any, from <CR><LF> pair */
 	    read = gerb_fgetc(fd);
-	    if (read != '\n' && read != EOF)
+	    if (read != '\n' && read != EOF) {
 		    gerb_ungetc(fd);
+	    }
 	    break;
 
 	case ' ' :	/* White space */
@@ -979,11 +998,12 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	}
     }
 
-    gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_ERROR, -1,
-	    _("No EOF found in drill file \"%s\""), fd->filename);
+    if (!parsing_done) {
+	gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_ERROR, -1,
+		_("No EOF found in drill file \"%s\""), fd->filename);
+    }
 
-drill_parse_end:
-    dprintf ("%s():  Populating file attributes\n", __FUNCTION__);
+    DPRINTF("%s():  Populating file attributes\n", __FUNCTION__);
 
     hid_attrs = image->info->attr_list;
 
@@ -1012,7 +1032,7 @@ drill_parse_end:
 	break;
 	
     case FMT_USER:
-	dprintf ("%s():  Keeping user specified number of decimal places (%d)\n",
+	DPRINTF("%s():  Keeping user specified number of decimal places (%d)\n",
 		 __FUNCTION__,
 		 hid_attrs[HA_digits].default_val.int_value);
 	break;
@@ -1066,10 +1086,11 @@ drill_file_p(gerb_file_t *fd, gboolean *returnFoundBinary)
     gboolean end_comments=FALSE;
  
     tbuf = g_malloc(MAXL);
-    if (tbuf == NULL) 
+    if (tbuf == NULL) {
 	GERB_FATAL_ERROR(
 		"malloc buf failed while checking for drill file in %s()",
 		__FUNCTION__);
+    }
 
     while (fgets(tbuf, MAXL, fd->fd) != NULL) {
 	len = strlen(tbuf);
@@ -1089,11 +1110,12 @@ drill_file_p(gerb_file_t *fd, gboolean *returnFoundBinary)
 					
 				}
 			}
-			if(!end_comments)
+			if(!end_comments) {
 				continue;
-		}			
-		else 
+			}
+		} else {
 			end_comments=TRUE;
+		}
 	}
 
 	/* First look through the file for indications of its type */
@@ -1120,8 +1142,9 @@ drill_file_p(gerb_file_t *fd, gboolean *returnFoundBinary)
 
 	/* Check for % on its own line at end of header */
 	if ((letter = g_strstr_len(buf, len, "%")) != NULL) {
-	    if ((letter[1] ==  '\r') || (letter[1] ==  '\n'))
+	    if ((letter[1] ==  '\r') || (letter[1] ==  '\n')) {
 		found_percent = TRUE;
+	    }
 	}
 
 	/* Check for T<number> */
@@ -1155,15 +1178,16 @@ drill_file_p(gerb_file_t *fd, gboolean *returnFoundBinary)
     *returnFoundBinary = found_binary;
     
     /* Now form logical expression determining if this is a drill file */
-    if ( ((found_X || found_Y) && found_T) && 
-	 (found_M48 || (found_percent && found_M30)) ) 
+    if ( ((found_X || found_Y) && found_T) &&
+	 (found_M48 || (found_percent && found_M30)) ) {
 	return TRUE;
-    else if (found_M48 && found_percent && found_M30)
-	/* Pathological case of drill file with valid header 
+    } else if (found_M48 && found_percent && found_M30) {
+	/* Pathological case of drill file with valid header
 	   and EOF but no drill XY locations. */
 	return TRUE;
-    else 
+    } else {
 	return FALSE;
+    }
 } /* drill_file_p */
 
 
@@ -1184,12 +1208,12 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
     gchar *tmps;
     gchar *string;
 
-    dprintf("---> entering %s()...\n", __FUNCTION__);
+    DPRINTF("---> entering %s()...\n", __FUNCTION__);
 
     /* Sneak a peek at what's hiding after the 'T'. Ugly fix for
        broken headers from Orcad, which is crap */
     temp = gerb_fgetc(fd);
-    dprintf("  Found a char '%s' (0x%02x) after the T\n",
+    DPRINTF("  Found a char '%s' (0x%02x) after the T\n",
 	    gerbv_escape_char(temp), temp);
     
     /* might be a tool tool change stop switch on/off*/
@@ -1229,10 +1253,11 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
     gerb_ungetc(fd);
 
     tool_num = (int) gerb_fgetint(fd, NULL);
-    dprintf ("  Handling tool T%d at line %u\n", tool_num, file_line);
+    DPRINTF("  Handling tool T%d at line %u\n", tool_num, file_line);
 
-    if (tool_num == 0) 
+    if (tool_num == 0) {
 	return tool_num; /* T00 is a command to unload the drill */
+    }
 
     if (tool_num < TOOL_MIN || tool_num >= TOOL_MAX) {
 	gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_ERROR, -1,
@@ -1255,7 +1280,7 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
 	switch((char)temp) {
 	case 'C':
 	    size = read_double(fd, state->header_number_format, GERBV_OMIT_ZEROS_TRAILING, state->decimals);
-	    dprintf ("  Read a size of %g\n", size);
+	    DPRINTF("  Read a size of %g\n", size);
 
 	    if (state->unit == GERBV_UNIT_MM) {
 		size /= 25.4;
@@ -1300,9 +1325,10 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
 		} else {
 		    apert = image->aperture[tool_num] =
 						g_new0(gerbv_aperture_t, 1);
-		    if (apert == NULL)
+		    if (apert == NULL) {
 			GERB_FATAL_ERROR("malloc tool failed in %s()",
 					__FUNCTION__);
+		    }
 
 		    /* There's really no way of knowing what unit the tools
 		       are defined in without sneaking a peek in the rest of
@@ -1346,8 +1372,9 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
 			"drill file \"%s\""), fd->filename);
 
 	/* Restore new line character for processing */
-	if ('\n' == temp || '\r' == temp)
+	if ('\n' == temp || '\r' == temp) {
 	    gerb_ungetc(fd);
+	}
 	}
     }   /* while(!done) */  /* Done looking at tool definitions */
 
@@ -1357,8 +1384,9 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
         double dia;
 
 	apert = image->aperture[tool_num] = g_new0(gerbv_aperture_t, 1);
-	if (apert == NULL)
+	if (apert == NULL) {
 	    GERB_FATAL_ERROR("malloc tool failed in %s()", __FUNCTION__);
+	}
 
         /* See if we have the tool table */
         dia = gerbv_get_tool_diameter(tool_num);
@@ -1402,7 +1430,7 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
 	}
     } /* if(image->aperture[tool_num] == NULL) */	
     
-    dprintf("<----  ...leaving %s()\n", __FUNCTION__);
+    DPRINTF("<----  ...leaving %s()\n", __FUNCTION__);
 
     return tool_num;
 } /* drill_parse_T_code() */
@@ -1417,7 +1445,7 @@ drill_parse_M_code(gerb_file_t *fd, drill_state_t *state,
     drill_m_code_t m_code;
     char op[3];
 
-    dprintf("---> entering %s() ...\n", __FUNCTION__);
+    DPRINTF("---> entering %s() ...\n", __FUNCTION__);
 
     op[0] = gerb_fgetc(fd);
     op[1] = gerb_fgetc(fd);
@@ -1432,7 +1460,7 @@ drill_parse_M_code(gerb_file_t *fd, drill_state_t *state,
 	return DRILL_M_UNKNOWN;
     }
 
-    dprintf("  Compare M-code \"%s\" at line %u\n", op, file_line);
+    DPRINTF("  Compare M-code \"%s\" at line %u\n", op, file_line);
 
     switch (m_code = atoi(op)) {
     case 0:
@@ -1494,7 +1522,7 @@ drill_parse_M_code(gerb_file_t *fd, drill_state_t *state,
     }
 
 
-    dprintf("<----  ...leaving %s()\n", __FUNCTION__);
+    DPRINTF("<----  ...leaving %s()\n", __FUNCTION__);
 
     return m_code;
 } /* drill_parse_M_code() */
@@ -1507,7 +1535,7 @@ drill_parse_header_is_metric(gerb_file_t *fd, drill_state_t *state,
     gerbv_drill_stats_t *stats = image->drill_stats;
     char c, op[3];
 
-    dprintf("    %s(): entering\n", __FUNCTION__);
+    DPRINTF("    %s(): entering\n", __FUNCTION__);
 
     /* METRIC is not an actual M code but a command that is only
      * acceptable within the header.
@@ -1516,8 +1544,9 @@ drill_parse_header_is_metric(gerb_file_t *fd, drill_state_t *state,
      * METRIC[,{TZ|LZ}][,{000.000|000.00|0000.00}]
      */
 
-    if (DRILL_HEADER != state->curr_section)
+    if (DRILL_HEADER != state->curr_section) {
 	return 0;
+    }
 
     switch (file_check_str(fd, "METRIC")) {
     case -1:
@@ -1530,25 +1559,30 @@ drill_parse_header_is_metric(gerb_file_t *fd, drill_state_t *state,
 	return 0;
     }
 
-header_again:
+    for (;;) {
+	gboolean found_junk = FALSE;
 
-    if (',' != gerb_fgetc(fd)) {
-	gerb_ungetc(fd);
-	eat_line(fd);
-    } else {
+	if (',' != gerb_fgetc(fd)) {
+	    gerb_ungetc(fd);
+	    eat_line(fd);
+	    break;
+	}
+
 	/* Is it TZ, LZ, or zerofmt? */
 	switch (c = gerb_fgetc(fd)) {
 	case 'T':
 	case 'L':
-	    if ('Z' != gerb_fgetc(fd))
-		goto header_junk;
+	    if ('Z' != gerb_fgetc(fd)) {
+		found_junk = TRUE;
+		break;
+	    }
 
 	    if (c == 'L') {
-		dprintf ("    %s(): Detected a file that probably has "
+		DPRINTF("    %s(): Detected a file that probably has "
 			"trailing zero suppression\n", __FUNCTION__);
 		image->format->omit_zeros = GERBV_OMIT_ZEROS_TRAILING;
 	    } else {
-		dprintf ("    %s(): Detected a file that probably has "
+		DPRINTF("    %s(): Detected a file that probably has "
 			"leading zero suppression\n", __FUNCTION__);
 		image->format->omit_zeros = GERBV_OMIT_ZEROS_LEADING;
 	    }
@@ -1574,18 +1608,20 @@ header_again:
 		state->decimals = 3;
 	    }
 
-	    if (',' == gerb_fgetc(fd))
-		/* Anticipate number format will follow */
-		goto header_again;
+	    if (',' == gerb_fgetc(fd)) {
+		/* Another option follows */
+		continue;
+	    }
 
 	    gerb_ungetc(fd);
-
 	    break;
 
 	case '0':
 	    if ('0' != gerb_fgetc(fd)
-	    ||  '0' != gerb_fgetc(fd))
-		goto header_junk;
+	    ||  '0' != gerb_fgetc(fd)) {
+		found_junk = TRUE;
+		break;
+	    }
 
 	    /* We just parsed three 0s, the remainder options
 	       so far are: .000 | .00 | 0.00 */
@@ -1593,15 +1629,19 @@ header_again:
 	    op[1] = gerb_fgetc(fd);
 	    op[2] = '\0';
 	    if (EOF == op[0]
-	    ||  EOF == op[1])
-		goto header_junk;
+	    ||  EOF == op[1]) {
+		found_junk = TRUE;
+		break;
+	    }
 
 	    if (0 == strcmp(op, "0.")) {
 		/* expecting FMT_0000_00,
 		   two trailing 0s must follow */
 		if ('0' != gerb_fgetc(fd)
-		||  '0' != gerb_fgetc(fd))
-		    goto header_junk;
+		||  '0' != gerb_fgetc(fd)) {
+		    found_junk = TRUE;
+		    break;
+		}
 
 		eat_line(fd);
 
@@ -1612,13 +1652,17 @@ header_again:
 		break;
 	    }
 
-	    if (0 != strcmp(op, ".0"))
-		goto header_junk;
+	    if (0 != strcmp(op, ".0")) {
+		found_junk = TRUE;
+		break;
+	    }
 
 	    /* Must be either FMT_000_000 or FMT_000_00, depending
 	     * on whether one or two 0s are following */
-	    if ('0' != gerb_fgetc(fd))
-		goto header_junk;
+	    if ('0' != gerb_fgetc(fd)) {
+		found_junk = TRUE;
+		break;
+	    }
 
 	    if ('0' == gerb_fgetc(fd)
 	    &&  state->autod) {
@@ -1637,7 +1681,11 @@ header_again:
 	    break;
 
 	default:
-header_junk:
+	    found_junk = TRUE;
+	    break;
+	}
+
+	if (found_junk) {
 	    gerb_ungetc(fd);
 	    eat_line(fd);
 
@@ -1646,8 +1694,9 @@ header_junk:
 		    _("Found junk after METRIC command "
 			"at line %u in file \"%s\""),
 		    file_line, fd->filename);
-	    break;
 	}
+
+	break;
     }
 
     state->unit = GERBV_UNIT_MM;
@@ -1665,7 +1714,7 @@ drill_parse_header_is_metric_comment(gerb_file_t *fd, drill_state_t *state,
                                      gerbv_image_t *image, unsigned int file_line) {
   gerbv_drill_stats_t *stats = image->drill_stats;
 
-  dprintf("    %s(): entering\n", __FUNCTION__);
+  DPRINTF("    %s(): entering\n", __FUNCTION__);
   /* The leading semicolon is already gone. */
   if (DRILL_HEADER != state->curr_section) {
     return 0;
@@ -1737,10 +1786,11 @@ drill_parse_header_is_inch(gerb_file_t *fd, drill_state_t *state,
     gerbv_drill_stats_t *stats = image->drill_stats;
     char c;
 
-    dprintf("    %s(): entering\n", __FUNCTION__);
+    DPRINTF("    %s(): entering\n", __FUNCTION__);
 
-    if (DRILL_HEADER != state->curr_section) 
+    if (DRILL_HEADER != state->curr_section) {
 	return 0;
+    }
 
     switch (file_check_str(fd, "INCH")) {
     case -1:
@@ -1854,7 +1904,7 @@ drill_parse_G_code(gerb_file_t *fd, gerbv_image_t *image, unsigned int file_line
     drill_g_code_t g_code;
     gerbv_drill_stats_t *stats = image->drill_stats;
     
-    dprintf("---> entering %s()...\n", __FUNCTION__);
+    DPRINTF("---> entering %s()...\n", __FUNCTION__);
 
     op[0] = gerb_fgetc(fd);
     op[1] = gerb_fgetc(fd);
@@ -1868,7 +1918,7 @@ drill_parse_G_code(gerb_file_t *fd, gerbv_image_t *image, unsigned int file_line
 	return DRILL_G_UNKNOWN;
     }
 
-    dprintf("  Compare G-code \"%s\" at line %u\n", op, file_line);
+    DPRINTF("  Compare G-code \"%s\" at line %u\n", op, file_line);
 
     switch (g_code = atoi(op)) {
     case 0:
@@ -1912,7 +1962,7 @@ drill_parse_G_code(gerb_file_t *fd, gerbv_image_t *image, unsigned int file_line
 	break;
     }
 
-    dprintf("<----  ...leaving %s()\n", __FUNCTION__);
+    DPRINTF("<----  ...leaving %s()\n", __FUNCTION__);
 
     return g_code;
 } /* drill_parse_G_code() */
@@ -2020,11 +2070,13 @@ read_double(gerb_file_t *fd, number_fmt_t fmt, gerbv_omit_zeros_t omit_zeros, in
        * FIXME -- if we are going to do this, don't we need a
        * locale-independent strtod()?  I think pcb has one.
        */
-      if(read == ',')
+      if(read == ',') {
 	    read = '.'; /* adjust for strtod() */
+      }
 
-	if(read == '-' || read == '+')
+	if(read == '-' || read == '+') {
 	    sign_prepend = TRUE;
+	}
 
       temp[i++] = (char)read;
       read = gerb_fgetc(fd);
@@ -2074,8 +2126,9 @@ read_double(gerb_file_t *fd, number_fmt_t fmt, gerbv_omit_zeros_t omit_zeros, in
 	    }
 	    
 	    /* need to add an extra char for '+' or '-' */
-	    if (sign_prepend)
+	    if (sign_prepend) {
 	      wantdigits++;
+	    }
 
 
 	    /* 
@@ -2093,7 +2146,7 @@ read_double(gerb_file_t *fd, number_fmt_t fmt, gerbv_omit_zeros_t omit_zeros, in
 	     * preceeding the decimal point, insert a decimal point
 	     * and append the rest of the digits.
 	     */
-	    dprintf("%s():  wantdigits = %d, strlen(\"%s\") = %ld\n",
+	    DPRINTF("%s():  wantdigits = %d, strlen(\"%s\") = %ld\n",
 		    __FUNCTION__, wantdigits, temp, (long) strlen(temp));
 	    for (i = 0 ; i < wantdigits && i < strlen(temp) ; i++) {
 	      tmp2[i] = temp[i];
@@ -2105,7 +2158,7 @@ read_double(gerb_file_t *fd, number_fmt_t fmt, gerbv_omit_zeros_t omit_zeros, in
 	    for ( ; i <= strlen(temp) ; i++) {
 	      tmp2[i] = temp[i-1];
 	    }
-	    dprintf("%s():  After dealing with trailing zero suppression, convert \"%s\"\n", __FUNCTION__, tmp2);
+	    DPRINTF("%s():  After dealing with trailing zero suppression, convert \"%s\"\n", __FUNCTION__, tmp2);
 	    scale = 1.0;
 	    
 	    for (i = 0 ; i <= strlen(tmp2) && i < sizeof (temp) ; i++) {
@@ -2146,7 +2199,7 @@ read_double(gerb_file_t *fd, number_fmt_t fmt, gerbv_omit_zeros_t omit_zeros, in
 	result = strtod(temp, NULL) * scale;
     }
 
-    dprintf("    %s()=%f: fmt=%d, omit_zeros=%d, decimals=%d \n",
+    DPRINTF("    %s()=%f: fmt=%d, omit_zeros=%d, decimals=%d \n",
 		    __FUNCTION__, result, fmt, omit_zeros, decimals);
 
     return result;
@@ -2165,8 +2218,9 @@ eat_line(gerb_file_t *fd)
     } while (read != '\n' && read != '\r' && read != EOF);
 
     /* Restore new line character for processing */
-    if (read != EOF)
+    if (read != EOF) {
 	gerb_ungetc(fd);
+    }
 } /* eat_line */
 
 /* -------------------------------------------------------------- */
@@ -2181,8 +2235,9 @@ eat_whitespace(gerb_file_t *fd)
     } while ((read == ' ' || read == '\t') && read != EOF);
 
     /* Restore the non-whitespace character for processing */
-    if (read != EOF)
+    if (read != EOF) {
 	gerb_ungetc(fd);
+    }
 } /* eat_whitespace */
 
 /* -------------------------------------------------------------- */
@@ -2207,8 +2262,9 @@ get_line(gerb_file_t *fd)
 	}
 
 	/* Restore new line character for processing */
-	if (read != EOF)
+	if (read != EOF) {
 	    gerb_ungetc(fd);
+	}
 
 	return tmps;
 } /* get_line */
@@ -2228,8 +2284,9 @@ file_check_str(gerb_file_t *fd, const char *str)
 
 	c = gerb_fgetc(fd);
 
-	if (c == EOF)
+	if (c == EOF) {
 	    return -1;
+	}
 
 	if (c != str[i]) {
 	    do {

--- a/src/drill_stats.c
+++ b/src/drill_stats.c
@@ -37,7 +37,7 @@
 #include "drill_stats.h"
 #include "gerb_stats.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 
 /* ------------------------------------------------------- */
@@ -115,7 +115,7 @@ gerbv_drill_stats_add_layer(gerbv_drill_stats_t *accum_stats,
     gerbv_error_list_t *error;
     char *tmps, *tmps2;
 
-    dprintf("--->  Entering gerbv_drill_stats_add_layer ..... \n");
+    DPRINTF("--->  Entering gerbv_drill_stats_add_layer ..... \n");
 
     accum_stats->layer_count++;
 
@@ -156,7 +156,7 @@ gerbv_drill_stats_add_layer(gerbv_drill_stats_t *accum_stats,
     for (drill = input_stats->drill_list;
          drill != NULL;
 	 drill = drill->next) {
-	dprintf("   In gerbv_drill_stats_add_layer, adding drill_num = %d to list\n",
+	DPRINTF("   In gerbv_drill_stats_add_layer, adding drill_num = %d to list\n",
 		drill->drill_num);
 	/* First add this input drill to the accumulated list.
 	 * Drills already in accum list will not be added. */
@@ -166,7 +166,7 @@ gerbv_drill_stats_add_layer(gerbv_drill_stats_t *accum_stats,
 				      drill->drill_unit);
 
 	/* Now add count of input drill to accum list */
-	dprintf("   adding count %d of drills for drill %d\n", 
+	DPRINTF("   adding count %d of drills for drill %d\n", 
 		drill->drill_count, drill->drill_num);
 	drill_stats_add_to_drill_counter(accum_stats->drill_list,
 					 drill->drill_num,
@@ -215,7 +215,7 @@ gerbv_drill_stats_add_layer(gerbv_drill_stats_t *accum_stats,
     }
 
 
-    dprintf("<---  .... Leaving gerbv_drill_stats_add_layer.\n");
+    DPRINTF("<---  .... Leaving gerbv_drill_stats_add_layer.\n");
 	    
     return;
 }
@@ -264,15 +264,15 @@ drill_stats_add_to_drill_list(gerbv_drill_list_t *drill_list_in,
     gerbv_drill_list_t *drill;
     gerbv_drill_list_t *drill_last = NULL;
 
-    dprintf ("%s(%p, %d, %g, \"%s\")\n", __FUNCTION__, drill_list_in, drill_num_in,
+    DPRINTF("%s(%p, %d, %g, \"%s\")\n", __FUNCTION__, drill_list_in, drill_num_in,
 	     drill_size_in, drill_unit_in);
 
-    dprintf("   ---> Entering drill_stats_add_to_drill_list, first drill_num in list = %d ...\n", 
+    DPRINTF("   ---> Entering drill_stats_add_to_drill_list, first drill_num in list = %d ...\n", 
 	    drill_list_in->drill_num);
 
     /* First check for empty list.  If empty, then just add this drill */
     if (drill_list_in->drill_num == -1) {
-	dprintf("    .... In drill_stats_add_to_drill_list, adding first drill, no %d\n", 
+	DPRINTF("    .... In drill_stats_add_to_drill_list, adding first drill, no %d\n", 
 		drill_num_in);
 	drill_list_in->drill_num = drill_num_in;
 	drill_list_in->drill_size = drill_size_in;
@@ -285,10 +285,10 @@ drill_stats_add_to_drill_list(gerbv_drill_list_t *drill_list_in,
     for(drill = drill_list_in; 
 	drill != NULL; 
 	drill = (gerbv_drill_list_t *) drill->next) {
-	dprintf("checking this drill_num %d against that in list %d.\n", 
+	DPRINTF("checking this drill_num %d against that in list %d.\n", 
 		drill_num_in, drill->drill_num);
 	if (drill_num_in == drill->drill_num) {
-	    dprintf("   .... In drill_stats_add_to_drill_list, drill no %d already in list\n", 
+	    DPRINTF("   .... In drill_stats_add_to_drill_list, drill no %d already in list\n", 
 		    drill_num_in);
 	    return;  /* Found it in list, so return */
 	}
@@ -301,7 +301,7 @@ drill_stats_add_to_drill_list(gerbv_drill_list_t *drill_list_in,
     }
 
     /* Now set various parameters based upon calling args */
-    dprintf("    .... In drill_stats_add_to_drill_list, adding new drill, no %d\n", 
+    DPRINTF("    .... In drill_stats_add_to_drill_list, adding new drill, no %d\n", 
 	    drill_num_in);
     drill_list_new->drill_num = drill_num_in;
     drill_list_new->drill_size = drill_size_in;
@@ -310,7 +310,7 @@ drill_stats_add_to_drill_list(gerbv_drill_list_t *drill_list_in,
     drill_list_new->next = NULL;
     drill_last->next = drill_list_new;
 
-    dprintf("   <---- ... leaving drill_stats_add_to_drill_list.\n");
+    DPRINTF("   <---- ... leaving drill_stats_add_to_drill_list.\n");
     return;
 }
 
@@ -322,26 +322,26 @@ drill_stats_modify_drill_list(gerbv_drill_list_t *drill_list_in,
 
     gerbv_drill_list_t *drill;
 
-    dprintf("   ---> Entering drill_stats_modify_drill_list, first drill_num in list = %d ...\n", 
+    DPRINTF("   ---> Entering drill_stats_modify_drill_list, first drill_num in list = %d ...\n", 
 	    drill_list_in->drill_num);
 
     /* Look for this drill num in list */
     for(drill = drill_list_in; 
 	drill != NULL; 
 	drill = (gerbv_drill_list_t *) drill->next) {
-	dprintf("checking this drill_num %d against that in list %d.\n", 
+	DPRINTF("checking this drill_num %d against that in list %d.\n", 
 		drill_num_in, drill->drill_num);
 	if (drill_num_in == drill->drill_num) {
-	    dprintf("   .... Found it, now update it ....\n");
+	    DPRINTF("   .... Found it, now update it ....\n");
 	    drill->drill_size = drill_size_in;
 	    if (drill->drill_unit) 
 		g_free(drill->drill_unit);
 	    drill->drill_unit = g_strdup_printf("%s", drill_unit_in);
-	    dprintf("   <---- ... Modified drill.  leaving drill_stats_modify_drill_list.\n");
+	    DPRINTF("   <---- ... Modified drill.  leaving drill_stats_modify_drill_list.\n");
 	    return;
 	}
     }
-    dprintf("   <---- ... Did not find drill.  leaving drill_stats_modify_drill_list.\n");
+    DPRINTF("   <---- ... Did not find drill.  leaving drill_stats_modify_drill_list.\n");
     return;
 }
 
@@ -350,19 +350,19 @@ void
 drill_stats_increment_drill_counter(gerbv_drill_list_t *drill_list_in, 
 				    int drill_num_in) {
 
-    dprintf("   ----> Entering drill_stats_increment_drill_counter......\n");
+    DPRINTF("   ----> Entering drill_stats_increment_drill_counter......\n");
     /* First check to see if this drill is already in the list */
     gerbv_drill_list_t *drill;
     for(drill = drill_list_in; drill != NULL; drill = drill->next) {
 	if (drill_num_in == drill->drill_num) {
 	    drill->drill_count++;
-	    dprintf("         .... incrementing drill count.  drill_num = %d, drill_count = %d.\n",
+	    DPRINTF("         .... incrementing drill count.  drill_num = %d, drill_count = %d.\n",
 		    drill_list_in->drill_num, drill->drill_count);
-	    dprintf("   <---- .... Leaving drill_stats_increment_drill_counter after incrementing counter.\n");
+	    DPRINTF("   <---- .... Leaving drill_stats_increment_drill_counter after incrementing counter.\n");
 	    return;
 	}
     }
-    dprintf("   <---- .... Leaving drill_stats_increment_drill_counter without incrementing any counter.\n");
+    DPRINTF("   <---- .... Leaving drill_stats_increment_drill_counter without incrementing any counter.\n");
 
 }
 
@@ -375,7 +375,7 @@ drill_stats_add_to_drill_counter(gerbv_drill_list_t *drill_list_in,
     gerbv_drill_list_t *drill;
     for(drill = drill_list_in; drill != NULL; drill = drill->next) {
 	if (drill_num_in == drill->drill_num) {
-	    dprintf("    In drill_stats_add_to_drill_counter, adding increment = %d drills to drill list\n", increment);
+	    DPRINTF("    In drill_stats_add_to_drill_counter, adding increment = %d drills to drill list\n", increment);
 	    drill->drill_count += increment;
 	    return;
 	}

--- a/src/export-drill.c
+++ b/src/export-drill.c
@@ -33,7 +33,7 @@
 
 #include "common.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define round(x) floor(x+0.5)
 

--- a/src/export-isel-drill.c
+++ b/src/export-isel-drill.c
@@ -39,7 +39,7 @@
 #include "common.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 #define round(x) floor(x+0.5)
 
 gboolean

--- a/src/export-rs274x.c
+++ b/src/export-rs274x.c
@@ -34,7 +34,7 @@
 
 #include "common.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define round(x) floor(x+0.5)
 

--- a/src/gerb_file.c
+++ b/src/gerb_file.c
@@ -50,7 +50,7 @@
 #include "gerb_file.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 gerb_file_t *
 gerb_fopen(char const * filename)
@@ -58,14 +58,14 @@ gerb_fopen(char const * filename)
     gerb_file_t *fd;
     struct stat statinfo;
     
-    dprintf("---> Entering gerb_fopen, filename = %s\n", filename);
+    DPRINTF("---> Entering gerb_fopen, filename = %s\n", filename);
 
     fd = g_new(gerb_file_t, 1);
     if (fd == NULL) {
 	return NULL;
     }
 
-    dprintf("     Doing fopen\n");
+    DPRINTF("     Doing fopen\n");
     /* fopen() can't open files with non ASCII filenames on windows */
     fd->fd = g_fopen(filename, "rb");
     if (fd->fd == NULL) {
@@ -73,7 +73,7 @@ gerb_fopen(char const * filename)
 	return NULL;
     }
 
-    dprintf("     Doing fstat\n");
+    DPRINTF("     Doing fstat\n");
     fd->ptr = 0;
     fd->fileno = fileno(fd->fd);
     if (fstat(fd->fileno, &statinfo) < 0) {
@@ -82,7 +82,7 @@ gerb_fopen(char const * filename)
 	return NULL;
     }
 
-    dprintf("     Checking S_ISREG\n");
+    DPRINTF("     Checking S_ISREG\n");
     if (!S_ISREG(statinfo.st_mode)) {
 	fclose(fd->fd);
 	g_free(fd);
@@ -90,7 +90,7 @@ gerb_fopen(char const * filename)
 	return NULL;
     }
 
-    dprintf("     Checking statinfo.st_size\n");
+    DPRINTF("     Checking statinfo.st_size\n");
     if ((int)statinfo.st_size == 0) {
 	fclose(fd->fd);
 	g_free(fd);
@@ -100,7 +100,7 @@ gerb_fopen(char const * filename)
 
 #ifdef HAVE_SYS_MMAN_H
 
-    dprintf("     Doing mmap\n");
+    DPRINTF("     Doing mmap\n");
     fd->datalen = (int)statinfo.st_size;
     fd->data = (char *)mmap(0, statinfo.st_size, PROT_READ, MAP_PRIVATE,
 			    fd->fileno, 0);
@@ -128,7 +128,7 @@ gerb_fopen(char const * filename)
 #else
     /* all systems without mmap, not only MINGW32 */
 
-    dprintf("     Doing calloc\n");
+    DPRINTF("     Doing calloc\n");
     fd->datalen = (int)statinfo.st_size;
     fd->data = calloc(1, statinfo.st_size + 1);
     if (fd->data == NULL) {
@@ -146,10 +146,10 @@ gerb_fopen(char const * filename)
 
 #endif
 
-    dprintf("     Setting filename\n");
+    DPRINTF("     Setting filename\n");
     fd->filename = g_strdup(filename);
 
-    dprintf("<--- Leaving gerb_fopen\n");
+    DPRINTF("<--- Leaving gerb_fopen\n");
     return fd;
 } /* gerb_fopen */
 
@@ -311,7 +311,7 @@ gerb_find_file(char const * filename, char **paths)
 #endif
 
     for (i = 0; paths[i] != NULL; i++) {
-        dprintf("%s():  Try paths[%d] = \"%s\"\n", __FUNCTION__, i, paths[i]);
+        DPRINTF("%s():  Try paths[%d] = \"%s\"\n", __FUNCTION__, i, paths[i]);
 
 	/*
 	 * Environment variables start with a $ sign 
@@ -334,7 +334,7 @@ gerb_find_file(char const * filename, char **paths)
 	    env_name[len] = '\0';
 
 	    env_value = getenv(env_name);
-            dprintf("%s():  Trying \"%s\" = \"%s\" from the environment\n",
+            DPRINTF("%s():  Trying \"%s\" = \"%s\" from the environment\n",
                 __FUNCTION__, env_name,
                 env_value == NULL ? "(null)" : env_value);
 
@@ -365,7 +365,7 @@ gerb_find_file(char const * filename, char **paths)
 	    curr_path = NULL;
 	  }
 	  
-	  dprintf("%s():  Tring to access \"%s\"\n", __FUNCTION__,
+	  DPRINTF("%s():  Tring to access \"%s\"\n", __FUNCTION__,
 		  complete_path);
 	  
 	  if (access(complete_path, R_OK) != -1)
@@ -379,7 +379,7 @@ gerb_find_file(char const * filename, char **paths)
     if (complete_path == NULL)
       errno = ENOENT;
     
-    dprintf("%s():  returning complete_path = \"%s\"\n", __FUNCTION__,
+    DPRINTF("%s():  returning complete_path = \"%s\"\n", __FUNCTION__,
 	    complete_path == NULL ? "(null)" : complete_path);
     
     return complete_path;

--- a/src/gerb_stats.c
+++ b/src/gerb_stats.c
@@ -35,7 +35,7 @@
 #include "common.h"
 #include "gerb_stats.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /* ------------------------------------------------------- */
 /** Allocates a new gerbv_stats structure
@@ -121,7 +121,7 @@ gerbv_stats_add_layer(gerbv_stats_t *accum_stats,
 		     gerbv_stats_t *input_stats,
 		     int this_layer) {
     
-    dprintf("---> Entering gerbv_stats_add_layer ... \n");
+    DPRINTF("---> Entering gerbv_stats_add_layer ... \n");
 
     gerbv_error_list_t *error;
     gerbv_aperture_list_t *aperture;
@@ -156,11 +156,11 @@ gerbv_stats_add_layer(gerbv_stats_t *accum_stats,
          D_code != NULL;
          D_code = D_code->next) {
         if (D_code->number != -1) {
-	  dprintf("     .... In gerbv_stats_add_layer, D code section, adding number = %d to accum_stats D list ...\n",
+	  DPRINTF("     .... In gerbv_stats_add_layer, D code section, adding number = %d to accum_stats D list ...\n",
 		  D_code->number);
 	  gerbv_stats_add_to_D_list(accum_stats->D_code_list,
 				   D_code->number);
-	  dprintf("     .... In gerbv_stats_add_layer, D code section, calling increment_D_count with count %d ...\n", 
+	  DPRINTF("     .... In gerbv_stats_add_layer, D code section, calling increment_D_count with count %d ...\n", 
 		  D_code->count);
 	  gerbv_stats_increment_D_list_count(accum_stats->D_code_list,
 					    D_code->number,
@@ -209,7 +209,7 @@ gerbv_stats_add_layer(gerbv_stats_t *accum_stats,
         }
     }
 
-    dprintf("<---- .... Leaving gerbv_stats_add_layer. \n");
+    DPRINTF("<---- .... Leaving gerbv_stats_add_layer. \n");
 
     return;
 }
@@ -361,14 +361,14 @@ gerbv_stats_new_aperture_list() {
     gerbv_aperture_list_t *aperture_list;
     int i;
 
-    dprintf("Mallocing new gerb aperture list\n");
+    DPRINTF("Mallocing new gerb aperture list\n");
     /* Malloc space for new aperture_list struct.  Return NULL if error. */
     if (NULL == (aperture_list = g_new(gerbv_aperture_list_t, 1))) {
-        dprintf("malloc new gerb aperture list failed in %s()\n", __FUNCTION__);
+        DPRINTF("malloc new gerb aperture list failed in %s()\n", __FUNCTION__);
         return NULL;
     }
 
-    dprintf("   Placing values in certain structs.\n");
+    DPRINTF("   Placing values in certain structs.\n");
     aperture_list->number = -1;
     aperture_list->count = 0;
     aperture_list->type = 0;
@@ -391,12 +391,12 @@ gerbv_stats_add_aperture(gerbv_aperture_list_t *aperture_list_in,
     gerbv_aperture_list_t *aperture;
     int i;
 
-    dprintf("   --->  Entering gerbv_stats_add_aperture ....\n"); 
+    DPRINTF("   --->  Entering gerbv_stats_add_aperture ....\n"); 
 
     /* First handle case where this is the first list element */
     if (aperture_list_in->number == -1) {
-	dprintf("     .... Adding first aperture to aperture list ... \n"); 
-	dprintf("     .... Aperture type = %d ... \n", type); 
+	DPRINTF("     .... Adding first aperture to aperture list ... \n"); 
+	DPRINTF("     .... Aperture type = %d ... \n", type); 
         aperture_list_in->number = number;
         aperture_list_in->type = type;
 	aperture_list_in->layer = layer;
@@ -404,7 +404,7 @@ gerbv_stats_add_aperture(gerbv_aperture_list_t *aperture_list_in,
 	    aperture_list_in->parameter[i] = parameter[i];
 	}
         aperture_list_in->next = NULL;
-	dprintf("   <---  .... Leaving gerbv_stats_add_aperture.\n"); 
+	DPRINTF("   <---  .... Leaving gerbv_stats_add_aperture.\n"); 
         return;
     }
 
@@ -414,15 +414,15 @@ gerbv_stats_add_aperture(gerbv_aperture_list_t *aperture_list_in,
 	aperture = aperture->next) {
         if ((aperture->number == number) &&
             (aperture->layer == layer) ) {
-	  dprintf("     .... This aperture is already in the list ... \n"); 
-	    dprintf("   <---  .... Leaving gerbv_stats_add_aperture.\n"); 
+	  DPRINTF("     .... This aperture is already in the list ... \n"); 
+	    DPRINTF("   <---  .... Leaving gerbv_stats_add_aperture.\n"); 
             return;  
         }
         aperture_last = aperture;  /* point to last element in list */
     }
     /* This aperture number is unique.  Therefore, add it to the list */
-    dprintf("     .... Adding another aperture to list ... \n"); 
-    dprintf("     .... Aperture type = %d ... \n", type); 
+    DPRINTF("     .... Adding another aperture to list ... \n"); 
+    DPRINTF("     .... Aperture type = %d ... \n", type); 
 	
     /* Now malloc space for new aperture list element */
     if (NULL == (aperture_list_new = g_new(gerbv_aperture_list_t, 1))) {
@@ -439,7 +439,7 @@ gerbv_stats_add_aperture(gerbv_aperture_list_t *aperture_list_in,
     }
     aperture_last->next = aperture_list_new;
 
-    dprintf("   <---  .... Leaving gerbv_stats_add_aperture.\n"); 
+    DPRINTF("   <---  .... Leaving gerbv_stats_add_aperture.\n"); 
 
     return;
 }
@@ -453,16 +453,16 @@ gerbv_stats_add_to_D_list(gerbv_aperture_list_t *D_list_in,
   gerbv_aperture_list_t *D_list_last=NULL;
   gerbv_aperture_list_t *D_list_new;
 
-    dprintf("   ----> Entering add_to_D_list, numbr = %d\n", number);
+    DPRINTF("   ----> Entering add_to_D_list, numbr = %d\n", number);
 
     /* First handle case where this is the first list element */
     if (D_list_in->number == -1) {
-	dprintf("     .... Adding first D code to D code list ... \n"); 
-	dprintf("     .... Aperture number = %d ... \n", number); 
+	DPRINTF("     .... Adding first D code to D code list ... \n"); 
+	DPRINTF("     .... Aperture number = %d ... \n", number); 
         D_list_in->number = number;
 	D_list_in->count = 0;
         D_list_in->next = NULL;
-	dprintf("   <---  .... Leaving add_to_D_list.\n"); 
+	DPRINTF("   <---  .... Leaving add_to_D_list.\n"); 
         return;
     }
 
@@ -471,15 +471,15 @@ gerbv_stats_add_to_D_list(gerbv_aperture_list_t *D_list_in,
 	D_list != NULL; 
 	D_list = D_list->next) {
         if (D_list->number == number) {
-  	    dprintf("    .... Found in D list .... \n");
-	    dprintf("   <---  .... Leaving add_to_D_list.\n"); 
+  	    DPRINTF("    .... Found in D list .... \n");
+	    DPRINTF("   <---  .... Leaving add_to_D_list.\n"); 
             return;  
         }
         D_list_last = D_list;  /* point to last element in list */
     }
 
     /* This aperture number is unique.  Therefore, add it to the list */
-    dprintf("     .... Adding another D code to D code list ... \n"); 
+    DPRINTF("     .... Adding another D code to D code list ... \n"); 
 	
     /* Malloc space for new aperture list element */
     if (NULL == (D_list_new = g_new(gerbv_aperture_list_t, 1))) {
@@ -492,7 +492,7 @@ gerbv_stats_add_to_D_list(gerbv_aperture_list_t *D_list_in,
     D_list_new->next = NULL;
     D_list_last->next = D_list_new;
 
-    dprintf("   <---  .... Leaving add_to_D_list.\n"); 
+    DPRINTF("   <---  .... Leaving add_to_D_list.\n"); 
 
     return;
 }
@@ -506,23 +506,23 @@ gerbv_stats_increment_D_list_count(gerbv_aperture_list_t *D_list_in,
   
     gerbv_aperture_list_t *D_list;
 
-    dprintf("   Entering inc_D_list_count, code = D%d, input count to add = %d\n", number, count);
+    DPRINTF("   Entering inc_D_list_count, code = D%d, input count to add = %d\n", number, count);
 
     /* Find D code in list and increment it */
     for(D_list = D_list_in; 
 	D_list != NULL; 
 	D_list = D_list->next) {
         if (D_list->number == number) {
-	    dprintf("    old count = %d\n", D_list->count);
+	    DPRINTF("    old count = %d\n", D_list->count);
 	    D_list->count += count;  /* Add to this aperture count, then return */
-	    dprintf("    updated count = %d\n", D_list->count);
+	    DPRINTF("    updated count = %d\n", D_list->count);
             return 0;  /* Return 0 for success */  
         }
     }
 
     /* This D number is not defined.  Therefore, flag error */
-    dprintf("    .... Didn't find this D code in defined list .... \n");
-    dprintf("   <---  .... Leaving inc_D_list_count.\n"); 
+    DPRINTF("    .... Didn't find this D code in defined list .... \n");
+    DPRINTF("   <---  .... Leaving inc_D_list_count.\n"); 
 
     gerbv_stats_printf(error, GERBV_MESSAGE_ERROR, -1,
 	    _("Undefined aperture number called out in D code"));

--- a/src/gerber.c
+++ b/src/gerber.c
@@ -43,7 +43,7 @@
 #include "amacro.h"
 
 #undef AMACRO_DEBUG
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define A2I(a,b) (((a & 0xff) << 8) + (b & 0xff))
 
@@ -159,15 +159,15 @@ gerber_parse_file_segment (gint levelOfRecursion, gerbv_image_t *image,
             scale = 1.0;
 	switch ((char)(read & 0xff)) {
 	case 'G':
-	    dprintf("... Found G code at line %ld\n", line_num);
+	    DPRINTF("... Found G code at line %ld\n", line_num);
 	    parse_G_code(fd, state, image, &line_num);
 	    break;
 	case 'D':
-	    dprintf("... Found D code at line %ld\n", line_num);
+	    DPRINTF("... Found D code at line %ld\n", line_num);
 	    parse_D_code(fd, state, image, &line_num);
 	    break;
 	case 'M':
-	    dprintf("... Found M code at line %ld\n", line_num);
+	    DPRINTF("... Found M code at line %ld\n", line_num);
 
 	    switch(parse_M_code(fd, image, &line_num)) {
 	    case 1 :
@@ -188,7 +188,7 @@ gerber_parse_file_segment (gint levelOfRecursion, gerbv_image_t *image,
 		    add_trailing_zeros_if_omitted(&coord,
 			    image->format->x_int + image->format->x_dec - len,
 			    image->format);
-	    dprintf("... Found X code %d at line %ld\n", coord, line_num);
+	    DPRINTF("... Found X code %d at line %ld\n", coord, line_num);
 	    if (image->format
 	    &&  image->format->coordinate==GERBV_COORDINATE_INCREMENTAL)
 	        state->curr_x += coord;
@@ -205,7 +205,7 @@ gerber_parse_file_segment (gint levelOfRecursion, gerbv_image_t *image,
 		    add_trailing_zeros_if_omitted(&coord,
 			    image->format->y_int + image->format->y_dec - len,
 			    image->format);
-	    dprintf("... Found Y code %d at line %ld\n", coord, line_num);
+	    DPRINTF("... Found Y code %d at line %ld\n", coord, line_num);
 	    if (image->format
 	    &&  image->format->coordinate==GERBV_COORDINATE_INCREMENTAL)
 	        state->curr_y += coord;
@@ -222,7 +222,7 @@ gerber_parse_file_segment (gint levelOfRecursion, gerbv_image_t *image,
 		    add_trailing_zeros_if_omitted(&coord,
 			    image->format->x_int + image->format->x_dec - len,
 			    image->format);
-	    dprintf("... Found I code %d at line %ld\n", coord, line_num);
+	    DPRINTF("... Found I code %d at line %ld\n", coord, line_num);
 	    state->delta_cp_x = coord;
 	    state->changed = 1;
 	    break;
@@ -234,13 +234,13 @@ gerber_parse_file_segment (gint levelOfRecursion, gerbv_image_t *image,
 		    add_trailing_zeros_if_omitted(&coord,
 			    image->format->y_int + image->format->y_dec - len,
 			    image->format);
-	    dprintf("... Found J code %d at line %ld\n", coord, line_num);
+	    DPRINTF("... Found J code %d at line %ld\n", coord, line_num);
 	    state->delta_cp_y = coord;
 	    state->changed = 1;
 	    break;
 
 	case '%':
-	    dprintf("... Found %% code at line %ld\n", line_num);
+	    DPRINTF("... Found %% code at line %ld\n", line_num);
 	    while (1) {
 	    	parse_rs274x(levelOfRecursion, fd, image, state, curr_net,
 				stats, directoryPath, &line_num);
@@ -288,7 +288,7 @@ gerber_parse_file_segment (gint levelOfRecursion, gerbv_image_t *image,
 	    }
 	    break;
 	case '*':  
-	    dprintf("... Found * code at line %ld\n", line_num);
+	    DPRINTF("... Found * code at line %ld\n", line_num);
 	    stats->star++;
 	    if (state->changed == 0) break;
 	    state->changed = 0;
@@ -469,7 +469,7 @@ gerber_parse_file_segment (gint levelOfRecursion, gerbv_image_t *image,
 
 		/* Update stats with current aperture number if not in polygon */
 		if (!state->in_parea_fill) {
-			dprintf("     In %s(), adding 1 to D_list ...\n",
+			DPRINTF("     In %s(), adding 1 to D_list ...\n",
 					__func__);
 			int retcode = gerbv_stats_increment_D_list_count(
 				stats->D_code_list, curr_net->aperture,
@@ -768,7 +768,7 @@ parse_gerb(gerb_file_t *fd, gchar *directoryPath)
     /*
      * Start parsing
      */
-    dprintf("In %s(), starting to parse file...\n", __func__);
+    DPRINTF("In %s(), starting to parse file...\n", __func__);
     foundEOF = gerber_parse_file_segment (1, image, state, curr_net, stats,
 					  fd, directoryPath);
 
@@ -778,7 +778,7 @@ parse_gerb(gerb_file_t *fd, gchar *directoryPath)
     }
     g_free(state);
     
-    dprintf("               ... done parsing Gerber file\n");
+    DPRINTF("               ... done parsing Gerber file\n");
     gerber_update_any_running_knockout_measurements (image);
     gerber_calculate_final_justify_effects(image);
 
@@ -807,7 +807,7 @@ gerber_is_rs274x_p(gerb_file_t *fd, gboolean *returnFoundBinary)
     gboolean found_X = FALSE;
     gboolean found_Y = FALSE;
    
-    dprintf ("%s(%p, %p), fd->fd = %p\n",
+    DPRINTF("%s(%p, %p), fd->fd = %p\n",
 		    __func__, fd, returnFoundBinary, fd->fd); 
     buf = (char *) g_malloc(MAXL);
     if (buf == NULL) 
@@ -815,7 +815,7 @@ gerber_is_rs274x_p(gerb_file_t *fd, gboolean *returnFoundBinary)
 			__FUNCTION__);
     
     while (fgets(buf, MAXL, fd->fd) != NULL) {
-        dprintf ("buf = \"%s\"\n", buf);
+        DPRINTF("buf = \"%s\"\n", buf);
 	len = strlen(buf);
     
 	/* First look through the file for indications of its type by
@@ -826,44 +826,44 @@ gerber_is_rs274x_p(gerb_file_t *fd, gboolean *returnFoundBinary)
 	    if (!isprint((int) buf[i]) && (buf[i] != '\r') && 
 		(buf[i] != '\n') && (buf[i] != '\t')) {
 		found_binary = TRUE;
-                dprintf ("found_binary (%d)\n", buf[i]);
+                DPRINTF("found_binary (%d)\n", buf[i]);
 	    }
 	}
 	if (g_strstr_len(buf, len, "%ADD")) {
 	    found_ADD = TRUE;
-            dprintf ("found_ADD\n");
+            DPRINTF("found_ADD\n");
 	}
 	if (g_strstr_len(buf, len, "D00") || g_strstr_len(buf, len, "D0")) {
 	    found_D0 = TRUE;
-            dprintf ("found_D0\n");
+            DPRINTF("found_D0\n");
 	}
 	if (g_strstr_len(buf, len, "D02") || g_strstr_len(buf, len, "D2")) {
 	    found_D2 = TRUE;
-            dprintf ("found_D2\n");
+            DPRINTF("found_D2\n");
 	}
 	if (g_strstr_len(buf, len, "M00") || g_strstr_len(buf, len, "M0")) {
 	    found_M0 = TRUE;
-            dprintf ("found_M0\n");
+            DPRINTF("found_M0\n");
 	}
 	if (g_strstr_len(buf, len, "M02") || g_strstr_len(buf, len, "M2")) {
 	    found_M2 = TRUE;
-            dprintf ("found_M2\n");
+            DPRINTF("found_M2\n");
 	}
 	if (g_strstr_len(buf, len, "*")) {
 	    found_star = TRUE;
-            dprintf ("found_star\n");
+            DPRINTF("found_star\n");
 	}
 	/* look for X<number> or Y<number> */
 	if ((letter = g_strstr_len(buf, len, "X")) != NULL) {
 	    if (isdigit((int) letter[1])) { /* grab char after X */
 		found_X = TRUE;
-                dprintf ("found_X\n");
+                DPRINTF("found_X\n");
 	    }
 	}
 	if ((letter = g_strstr_len(buf, len, "Y")) != NULL) {
 	    if (isdigit((int) letter[1])) { /* grab char after Y */
 		found_Y = TRUE;
-                dprintf ("found_Y\n");
+                DPRINTF("found_Y\n");
 	    }
 	}
     }
@@ -985,7 +985,7 @@ parse_G_code(gerb_file_t *fd, gerb_state_t *state,
     op_int=gerb_fgetint(fd, NULL);
 
     /* Emphasize text with new line '\n' in the beginning */
-    dprintf("\n     Found G%02d at line %ld (%s)\n",
+    DPRINTF("\n     Found G%02d at line %ld (%s)\n",
 		    op_int, *line_num_p, gerber_g_code_name(op_int));
     
     switch(op_int) {
@@ -1124,7 +1124,7 @@ parse_D_code(gerb_file_t *fd, gerb_state_t *state,
     gerbv_error_list_t *error_list = stats->error_list;
 
     a = gerb_fgetint(fd, NULL);
-    dprintf("     Found D%02d code at line %ld\n", a, *line_num_p);
+    DPRINTF("     Found D%02d code at line %ld\n", a, *line_num_p);
 
     switch(a) {
     case 0 : /* Invalid code */
@@ -1650,7 +1650,7 @@ parse_rs274x(gint levelOfRecursion, gerb_file_t *fd, gerbv_image_t *image,
 	else if ((ano >= 0) && (ano <= APERTURE_MAX)) {
 	    a->unit = state->state->unit;
 	    image->aperture[ano] = a;
-	    dprintf("     In %s(), adding new aperture to aperture list ...\n",
+	    DPRINTF("     In %s(), adding new aperture to aperture list ...\n",
 			    __func__);
 	    gerbv_stats_add_aperture(stats->aperture_list,
 				    -1, ano, 
@@ -2013,14 +2013,14 @@ simplify_aperture_macro(gerbv_aperture_t *aperture, gdouble scale)
 	     */
 	    switch(ip->data.ival) {
 	    case 1:
-		dprintf("  Aperture macro circle [1] (");
+		DPRINTF("  Aperture macro circle [1] (");
 		type = GERBV_APTYPE_MACRO_CIRCLE;
 		nuf_parameters = 5;
 		break;
 	    case 3:
 		break;
 	    case 4 :
-		dprintf("  Aperture macro outline [4] (");
+		DPRINTF("  Aperture macro outline [4] (");
 		type = GERBV_APTYPE_MACRO_OUTLINE;
 		/*
 		 * Number of parameters are:
@@ -2045,33 +2045,33 @@ simplify_aperture_macro(gerbv_aperture_t *aperture, gdouble scale)
 		}
 		break;
 	    case 5 :
-		dprintf("  Aperture macro polygon [5] (");
+		DPRINTF("  Aperture macro polygon [5] (");
 		type = GERBV_APTYPE_MACRO_POLYGON;
 		nuf_parameters = 6;
 		break;
 	    case 6 :
-		dprintf("  Aperture macro moire [6] (");
+		DPRINTF("  Aperture macro moire [6] (");
 		type = GERBV_APTYPE_MACRO_MOIRE;
 		nuf_parameters = 9;
 		break;
 	    case 7 :
-		dprintf("  Aperture macro thermal [7] (");
+		DPRINTF("  Aperture macro thermal [7] (");
 		type = GERBV_APTYPE_MACRO_THERMAL;
 		nuf_parameters = 6;
 		break;
 	    case 2  :
 	    case 20 :
-		dprintf("  Aperture macro line 20/2 (");
+		DPRINTF("  Aperture macro line 20/2 (");
 		type = GERBV_APTYPE_MACRO_LINE20;
 		nuf_parameters = 7;
 		break;
 	    case 21 :
-		dprintf("  Aperture macro line 21 (");
+		DPRINTF("  Aperture macro line 21 (");
 		type = GERBV_APTYPE_MACRO_LINE21;
 		nuf_parameters = 6;
 		break;
 	    case 22 :
-		dprintf("  Aperture macro line 22 (");
+		DPRINTF("  Aperture macro line 22 (");
 		type = GERBV_APTYPE_MACRO_LINE22;
 		nuf_parameters = 6;
 		break;
@@ -2193,10 +2193,10 @@ simplify_aperture_macro(gerbv_aperture_t *aperture, gdouble scale)
 
 #ifdef DEBUG
 		for (i = 0; i < nuf_parameters; i++) {
-		    dprintf("%f, ", s->stack[i]);
+		    DPRINTF("%f, ", s->stack[i]);
 		}
 #endif /* DEBUG */
-		dprintf(")\n");
+		DPRINTF(")\n");
 	    }
 
 	    /* 
@@ -2339,10 +2339,10 @@ parse_aperture_definition(gerb_file_t *fd, gerbv_aperture_t *aperture,
     gerb_ungetc(fd);
 
     if (aperture->type == GERBV_APTYPE_MACRO) {
-	dprintf("Simplifying aperture %d using aperture macro \"%s\"\n", ano,
+	DPRINTF("Simplifying aperture %d using aperture macro \"%s\"\n", ano,
 		aperture->amacro->name);
 	simplify_aperture_macro(aperture, scale);
-	dprintf("Done simplifying\n");
+	DPRINTF("Done simplifying\n");
     }
     
     g_free(ad);

--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -64,7 +64,7 @@
 #include "pick-and-place.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /** Return string name of gerbv_aperture_type_t aperture type. */
 const char *gerbv_aperture_type_name(gerbv_aperture_type_t type)
@@ -240,7 +240,7 @@ void
 gerbv_open_layer_from_filename(gerbv_project_t *gerbvProject, gchar const* filename)
 {
   gint idx_loaded;
-  dprintf("Opening filename = %s\n", filename);
+  DPRINTF("Opening filename = %s\n", filename);
   
   if (gerbv_open_image(gerbvProject, filename, ++gerbvProject->last_loaded, FALSE, NULL, 0, TRUE) == -1) {
     GERB_COMPILE_WARNING(_("Could not read \"%s\" (loaded %d)"),
@@ -249,7 +249,7 @@ gerbv_open_layer_from_filename(gerbv_project_t *gerbvProject, gchar const* filen
   } else {
     idx_loaded = gerbvProject->last_loaded;
     gerbvProject->file[idx_loaded]->layer_dirty = FALSE;
-    dprintf("     Successfully opened file!\n");	
+    DPRINTF("     Successfully opened file!\n");	
   }
 } /* gerbv_open_layer_from_filename */
 
@@ -259,7 +259,7 @@ gerbv_open_layer_from_filename_with_color(gerbv_project_t *gerbvProject, gchar c
 		guint16 red, guint16 green, guint16 blue, guint16 alpha)
 {
   gint idx_loaded;
-  dprintf("Opening filename = %s\n", filename);
+  DPRINTF("Opening filename = %s\n", filename);
   
   if (gerbv_open_image(gerbvProject, filename, ++gerbvProject->last_loaded, FALSE, NULL, 0, TRUE) == -1) {
     GERB_COMPILE_WARNING(_("Could not read \"%s\" (loaded %d)"),
@@ -271,7 +271,7 @@ gerbv_open_layer_from_filename_with_color(gerbv_project_t *gerbvProject, gchar c
     GdkColor colorTemplate = {0, red, green, blue};
     gerbvProject->file[idx_loaded]->color = colorTemplate;
     gerbvProject->file[idx_loaded]->alpha = alpha;
-    dprintf("     Successfully opened file!\n");	
+    DPRINTF("     Successfully opened file!\n");	
   }
 } /* gerbv_open_layer_from_filename_with_color */  
     
@@ -413,7 +413,7 @@ gerbv_add_parsed_image_to_project (gerbv_project_t *gerbvProject, gerbv_image_t 
     gerb_verify_error_t error = GERB_IMAGE_OK;
     int r, g, b; 
     
-    dprintf("In open_image, now error check file....\n");
+    DPRINTF("In open_image, now error check file....\n");
     error = gerbv_image_verify(parsed_image);
 
     if (error) {
@@ -513,7 +513,7 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
 	gerbvProject->max_files += 2;
     }
     
-    dprintf("In open_image, about to try opening filename = %s\n", filename);
+    DPRINTF("In open_image, about to try opening filename = %s\n", filename);
     
     fd = gerb_fopen(filename);
     if (fd == NULL) {
@@ -522,7 +522,7 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
 	return -1;
     }
 
-    dprintf("In open_image, successfully opened file.  Now check its type....\n");
+    DPRINTF("In open_image, successfully opened file.  Now check its type....\n");
     /* Here's where we decide what file type we have */
     /* Note: if the file has some invalid characters in it but still appears to
        be a valid file, we check with the user if he wants to continue (only
@@ -530,7 +530,7 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
        ahead and try to load it anyways) */
 
     if (gerber_is_rs274x_p(fd, &foundBinary)) {
-	dprintf("Found RS-274X file\n");
+	DPRINTF("Found RS-274X file\n");
 	if (!foundBinary || forceLoadFile) {
 		/* figure out the directory path in case parse_gerb needs to
 		 * load any include files */
@@ -539,12 +539,12 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
 		g_free (currentLoadDirectory);
 	}
     } else if(drill_file_p(fd, &foundBinary)) {
-	dprintf("Found drill file\n");
+	DPRINTF("Found drill file\n");
 	if (!foundBinary || forceLoadFile)
 	    parsed_image = parse_drillfile(fd, attr_list, n_attr, reload);
 	
     } else if (pick_and_place_check_file_type(fd, &foundBinary)) {
-	dprintf("Found pick-n-place file\n");
+	DPRINTF("Found pick-n-place file\n");
 	if (!foundBinary || forceLoadFile) {
 		if (!reload) {
 			pick_and_place_parse_file_to_images(fd, &parsed_image, &parsed_image2);
@@ -576,7 +576,7 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
     } else if (gerber_is_rs274d_p(fd)) {
 	gchar *str = g_strdup_printf(_("Most likely found a RS-274D file "
 			"\"%s\" ... trying to open anyways\n"), filename);
-	dprintf("%s", str);
+	DPRINTF("%s", str);
 	g_warning("%s", str);
 	g_free (str);
 
@@ -589,7 +589,7 @@ gerbv_open_image(gerbv_project_t *gerbvProject, gchar const* filename, int idx, 
 	}
     } else {
 	/* This is not a known file */
-	dprintf("Unknown filetype");
+	DPRINTF("Unknown filetype");
 	GERB_COMPILE_ERROR(_("%s: Unknown file type."), filename);
 	parsed_image = NULL;
     }
@@ -848,7 +848,7 @@ gerbv_render_to_pixmap_using_gdk (gerbv_project_t *gerbvProject, GdkPixmap *pixm
 			* Translation is to get it inside the allocated pixmap,
 			* which is not always centered perfectly for GTK/X.
 			*/
-			dprintf("  .... calling image2pixmap on image %d...\n", i);
+			DPRINTF("  .... calling image2pixmap on image %d...\n", i);
 			// Dirty scaling solution when using GDK; simply use scaling factor for x-axis, ignore y-axis
 			draw_gdk_image_to_pixmap(&clipmask, gerbvProject->file[i]->image,
 				renderInfo->scaleFactorX, -(renderInfo->lowerLeftX * renderInfo->scaleFactorX),
@@ -1137,7 +1137,7 @@ gerbv_transform_coord_for_image(double *x, double *y,
 		gerbv_get_fileinfo_for_image(image, project);
 
 	if (fileinfo == NULL) {
-		dprintf("%s(): NULL fileinfo\n", __func__);
+		DPRINTF("%s(): NULL fileinfo\n", __func__);
 		return -1;
 	}
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -51,7 +51,7 @@
 #include "gerbv_icon.h"
 #include "icons.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static const gchar *gerbv_win_title = N_("Gerbv — gEDA's Gerber Viewer");
 

--- a/src/main.c
+++ b/src/main.c
@@ -57,11 +57,8 @@
 #include "render.h"
 #include "project.h"
 
-#if (DEBUG)
-# define dprintf printf("%s():  ", __FUNCTION__); printf
-#else
-# define dprintf if(0) printf
-#endif
+/* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define NUMBER_OF_DEFAULT_COLORS 18
 #define NUMBER_OF_DEFAULT_TRANSFORMATIONS 20
@@ -194,7 +191,7 @@ main_open_project_from_filename(gerbv_project_t *gerbvProject, gchar *filename)
 	gint i, max_layer_num = -1;
 	gerbv_fileinfo_t *file_info;
 
-	dprintf("Opening project = %s\n", (gchar *) filename);
+	DPRINTF("Opening project = %s\n", (gchar *) filename);
 	list = read_project_file(filename);
 
 	if (!list) {
@@ -929,7 +926,7 @@ main(int argc, char *argv[])
      */
 
     if (project_filename) {
-	dprintf(_("Loading project %s...\n"), project_filename);
+	DPRINTF(_("Loading project %s...\n"), project_filename);
 	/* calculate the absolute pathname to the project if the user
 	   used a relative path */
 	g_free (mainProject->path);
@@ -978,7 +975,7 @@ main(int argc, char *argv[])
 
 	gdouble initial_radians = DEG2RAD(initial_rotation);
 
-	dprintf("Rotating all layers by %.0f degrees\n", (float) initial_rotation);
+	DPRINTF("Rotating all layers by %.0f degrees\n", (float) initial_rotation);
 	for(i = 0; i < mainProject->max_files; i++) {
 	    if (mainProject->file[i])
 		mainProject->file[i]->transform.rotation = initial_radians;
@@ -989,10 +986,10 @@ main(int argc, char *argv[])
 	/* Set initial mirroring of all layers */
 
 	if (initial_mirror_x) {
-	    dprintf("Mirroring all layers about x axis\n");
+	    DPRINTF("Mirroring all layers about x axis\n");
 	}
 	if (initial_mirror_y) {
-	    dprintf("Mirroring all layers about y axis\n");
+	    DPRINTF("Mirroring all layers about y axis\n");
 	}
 
 	for (i = 0; i < mainProject->max_files; i++) {

--- a/src/project.c
+++ b/src/project.c
@@ -102,7 +102,7 @@ static const char * known_versions[] = {
 };
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static project_list_t *project_list_top = NULL;
 
@@ -128,7 +128,7 @@ version_str_to_int( const char * str)
   if(str == NULL) {
     return -1;
   } else {
-    dprintf("%s(\"%s\")\n", __FUNCTION__, str);
+    DPRINTF("%s(\"%s\")\n", __FUNCTION__, str);
 
 
     /* 
@@ -145,7 +145,7 @@ version_str_to_int( const char * str)
 
     *ptr = '\0';
     r = 10000 * atoi(tmps);
-    dprintf("%s():  Converted \"%s\" to r = %d\n", __FUNCTION__, tmps, r);
+    DPRINTF("%s():  Converted \"%s\" to r = %d\n", __FUNCTION__, tmps, r);
 
     g_free(tmps);
 
@@ -173,7 +173,7 @@ version_str_to_int( const char * str)
 
     *ptr = '\0';
     r += 100 * atoi(tmps);
-    dprintf("%s():  Converted \"%s\" to r = %d\n", __FUNCTION__, tmps, r);
+    DPRINTF("%s():  Converted \"%s\" to r = %d\n", __FUNCTION__, tmps, r);
 
     g_free(dup);
 
@@ -193,11 +193,11 @@ version_str_to_int( const char * str)
     }
     tmps = ptr;
 
-    dprintf("%s():  Processing \"%s\"\n", __FUNCTION__, tmps);
+    DPRINTF("%s():  Processing \"%s\"\n", __FUNCTION__, tmps);
 
     if( strlen(tmps) == 1) {
       r += *tmps - 'A' + 1;
-      dprintf( "%s():  Converted \"%s\" to r = %d\n", __FUNCTION__, tmps, r);
+      DPRINTF( "%s():  Converted \"%s\" to r = %d\n", __FUNCTION__, tmps, r);
     } else if( strlen(tmps) == 2 ) {
       if( *tmps == 'Z' ) {
 	r += 26;
@@ -449,7 +449,7 @@ init_paths (char *argv0)
         haspath = 1;
     }
   
-  dprintf("%s (%s): haspath = %d\n", __FUNCTION__, argv0, haspath);
+  DPRINTF("%s (%s): haspath = %d\n", __FUNCTION__, argv0, haspath);
   if (haspath)
     {
       bindir = strdup (lrealpath (argv0));
@@ -471,7 +471,7 @@ init_paths (char *argv0)
           for (p = strtok (path, GERBV_PATH_DELIMETER); p && *p;
                p = strtok (NULL, GERBV_PATH_DELIMETER))
             {
-	      dprintf ("Looking for %s in %s\n", argv0, p);
+	      DPRINTF("Looking for %s in %s\n", argv0, p);
               if ( (tmps = malloc ( (strlen (argv0) + strlen (p) + 2) * sizeof (char))) == NULL )
                 {
                   fprintf (stderr, "malloc failed in %s()\n", __FUNCTION__);
@@ -481,7 +481,7 @@ init_paths (char *argv0)
               r = stat (tmps, &sb);
               if (r == 0)
                 {
-		  dprintf ("Found it:  \"%s\"\n", tmps);
+		  DPRINTF("Found it:  \"%s\"\n", tmps);
                   bindir = lrealpath (tmps);
                   found_bindir = 1;
                   free (tmps);
@@ -492,7 +492,7 @@ init_paths (char *argv0)
           free (path);
         }
     }
-  dprintf ("%s():  bindir = \"%s\"\n", __FUNCTION__, bindir);
+  DPRINTF("%s():  bindir = \"%s\"\n", __FUNCTION__, bindir);
   
 
   if (found_bindir)
@@ -507,8 +507,8 @@ init_paths (char *argv0)
         }
       if (t2 != NULL)
         *t2 = '\0';
-      dprintf ("After stripping off the executible name, we found\n");
-      dprintf ("bindir = \"%s\"\n", bindir);
+      DPRINTF("After stripping off the executible name, we found\n");
+      DPRINTF("bindir = \"%s\"\n", bindir);
       
     }
   else
@@ -541,10 +541,10 @@ init_paths (char *argv0)
 
   scmdatadir = g_strdup_printf ("%s%s%s", pkgdatadir, GERBV_DIR_SEPARATOR_S, GERBV_SCMSUBDIR);
 
-  dprintf ("%s():  bindir      = %s\n", __FUNCTION__, bindir);
-  dprintf ("%s():  exec_prefix = %s\n", __FUNCTION__, exec_prefix);
-  dprintf ("%s():  pkgdatadir  = %s\n", __FUNCTION__, pkgdatadir);
-  dprintf ("%s():  scmdatadir  = %s\n", __FUNCTION__, scmdatadir);
+  DPRINTF("%s():  bindir      = %s\n", __FUNCTION__, bindir);
+  DPRINTF("%s():  exec_prefix = %s\n", __FUNCTION__, exec_prefix);
+  DPRINTF("%s():  pkgdatadir  = %s\n", __FUNCTION__, pkgdatadir);
+  DPRINTF("%s():  scmdatadir  = %s\n", __FUNCTION__, scmdatadir);
   
 }
 
@@ -596,7 +596,7 @@ define_layer(scheme *sc, pointer args)
     const char *str;
     int layerno;
 
-    dprintf("--> entering %s: %s\n", __FILE__, __func__);
+    DPRINTF("--> entering %s: %s\n", __FILE__, __func__);
 
     if (!sc->vptr->is_pair(args)) {
 	GERB_MESSAGE(_("%s(): too few arguments"), __func__);
@@ -614,7 +614,7 @@ define_layer(scheme *sc, pointer args)
     }
 
     layerno = sc->vptr->ivalue(car_el);
-    dprintf("    layerno = %d\n", layerno);
+    DPRINTF("    layerno = %d\n", layerno);
     
     car_el = sc->vptr->pair_car(cdr_el);
     cdr_el = sc->vptr->pair_cdr(cdr_el);
@@ -690,7 +690,7 @@ define_layer(scheme *sc, pointer args)
 	    pointer attr_name, attr_type, attr_value;
 	    char *type;
 
-	    dprintf ("Parsing file attributes\n");
+	    DPRINTF("Parsing file attributes\n");
 
 	    attr_car_el = sc->vptr->pair_car (value);
 	    attr_cdr_el = sc->vptr->pair_cdr (value);
@@ -717,7 +717,7 @@ define_layer(scheme *sc, pointer args)
 		attr_value =  sc->vptr->pair_cdr (attr_value);
 		attr_value =  sc->vptr->pair_car (attr_value);
 
-		dprintf ("  attribute %s, type is %s, value is ", 
+		DPRINTF("  attribute %s, type is %s, value is ", 
 			 sc->vptr->symname(attr_name),
 			 sc->vptr->symname(attr_type));
 
@@ -727,37 +727,37 @@ define_layer(scheme *sc, pointer args)
 
 		plist->attr_list[p].default_val.str_value = NULL;
 		if (strcmp (type, "label") == 0) {
-		    dprintf ("%s", sc->vptr->string_value (attr_value));
+		    DPRINTF("%s", sc->vptr->string_value (attr_value));
 		    plist->attr_list[p].type = HID_Label;
 		    plist->attr_list[p].default_val.str_value =
 			strdup (sc->vptr->string_value (attr_value));
 
 		} else if (strcmp (type, "integer") == 0) {
-		    dprintf ("%ld", sc->vptr->ivalue (attr_value));
+		    DPRINTF("%ld", sc->vptr->ivalue (attr_value));
 		    plist->attr_list[p].type = HID_Integer;
 		    plist->attr_list[p].default_val.int_value =
 			sc->vptr->ivalue (attr_value);
 
 		} else if (strcmp (type, "real") == 0) {
-		    dprintf ("%g", sc->vptr->rvalue (attr_value));
+		    DPRINTF("%g", sc->vptr->rvalue (attr_value));
 		    plist->attr_list[p].type = HID_Real;
 		    plist->attr_list[p].default_val.real_value =
 			sc->vptr->rvalue (attr_value);
 
 		} else if (strcmp (type, "string") == 0) {
-		    dprintf ("%s", sc->vptr->string_value (attr_value));
+		    DPRINTF("%s", sc->vptr->string_value (attr_value));
 		    plist->attr_list[p].type = HID_String;
 		    plist->attr_list[p].default_val.str_value =
 			strdup (sc->vptr->string_value (attr_value));
 
 		} else if (strcmp (type, "boolean") == 0) {
-		    dprintf ("%ld", sc->vptr->ivalue (attr_value));
+		    DPRINTF("%ld", sc->vptr->ivalue (attr_value));
 		    plist->attr_list[p].type = HID_Boolean;
 		    plist->attr_list[p].default_val.int_value =
 			sc->vptr->ivalue (attr_value);
 
 		} else if (strcmp (type, "enum") == 0) {
-		    dprintf ("%ld", sc->vptr->ivalue (attr_value));
+		    DPRINTF("%ld", sc->vptr->ivalue (attr_value));
 		    plist->attr_list[p].type = HID_Enum;
 		    plist->attr_list[p].default_val.int_value =
 			sc->vptr->ivalue (attr_value);
@@ -769,7 +769,7 @@ define_layer(scheme *sc, pointer args)
 			     __FUNCTION__);
 
 		} else if (strcmp (type, "path") == 0) {
-		    dprintf ("%s", sc->vptr->string_value (attr_value));
+		    DPRINTF("%s", sc->vptr->string_value (attr_value));
 		    plist->attr_list[p].type = HID_Path;
 		    plist->attr_list[p].default_val.str_value =
 			strdup (sc->vptr->string_value (attr_value));
@@ -777,7 +777,7 @@ define_layer(scheme *sc, pointer args)
 		    fprintf (stderr, _("%s():  Unknown attribute type: \"%s\"\n"),
 			     __FUNCTION__, type);
 		}
-		dprintf ("\n");
+		DPRINTF("\n");
 
 		attr_car_el = sc->vptr->pair_car(attr_cdr_el);
 		attr_cdr_el = sc->vptr->pair_cdr(attr_cdr_el);
@@ -800,7 +800,7 @@ set_render_type(scheme *sc, pointer args)
     pointer car_el;
     int r;
 
-    dprintf("--> entering project.c:%s()\n", __FUNCTION__);
+    DPRINTF("--> entering project.c:%s()\n", __FUNCTION__);
 
     if (!sc->vptr->is_pair(args)){
 	GERB_MESSAGE(_("set-render-type!: Too few arguments"));
@@ -810,7 +810,7 @@ set_render_type(scheme *sc, pointer args)
     car_el = sc->vptr->pair_car(args);
 
     r = sc->vptr->ivalue (car_el);
-    dprintf ("%s():  Setting render type to %d\n", __FUNCTION__, r);
+    DPRINTF("%s():  Setting render type to %d\n", __FUNCTION__, r);
     interface_set_render_type (r);
 
     return sc->NIL;
@@ -824,7 +824,7 @@ gerbv_file_version(scheme *sc, pointer args)
     char *vstr;
     char *tmps;
 
-    dprintf("--> entering project.c:%s()\n", __FUNCTION__);
+    DPRINTF("--> entering project.c:%s()\n", __FUNCTION__);
 
     if (!sc->vptr->is_pair(args)){
 	GERB_MESSAGE(_("gerbv-file-version!: Too few arguments"));
@@ -853,7 +853,7 @@ gerbv_file_version(scheme *sc, pointer args)
       g_free (tmps);
     }
 
-    dprintf ("%s():  Read a project file version of %s (%d)\n", __FUNCTION__, vstr, r);
+    DPRINTF("%s():  Read a project file version of %s (%d)\n", __FUNCTION__, vstr, r);
 
     if ( r > version_str_to_int( GERBV_PROJECT_FILE_VERSION )) {
         /* The project file we're trying to load is too new for this version of gerbv */
@@ -1003,7 +1003,7 @@ read_project_file(char const* filename)
 	GERB_MESSAGE(_("Problem loading init.scm (%s)"), strerror(errno));
 	return NULL;
     }
-    dprintf("%s():  initfile = \"%s\"\n", __FUNCTION__, initfile);
+    DPRINTF("%s():  initfile = \"%s\"\n", __FUNCTION__, initfile);
 
     if ((fd = fopen(initfile, "r")) == NULL) {
 	scheme_deinit(sc);
@@ -1174,7 +1174,7 @@ write_project_file(gerbv_project_t *gerbvProject, char const* filename, project_
 		  break;
 
 	      case HID_Mixed:
-		  dprintf ("HID_Mixed\n");
+		  DPRINTF("HID_Mixed\n");
 		  fprintf (stderr, _("%s():  WARNING:  HID_Mixed is not yet supported.\n"),
 			   __FUNCTION__);
 		  break;

--- a/src/render.c
+++ b/src/render.c
@@ -63,7 +63,7 @@
 #endif
 #include "draw.h"
 
-#define dprintf if(DEBUG) printf
+#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 gerbv_render_info_t screenRenderInfo;
 
@@ -428,7 +428,7 @@ static void render_selection (void)
 void render_refresh_rendered_image_on_screen (void) {
 	GdkCursor *cursor;
 	
-	dprintf("----> Entering redraw_pixmap...\n");
+	DPRINTF("----> Entering redraw_pixmap...\n");
 	cursor = gdk_cursor_new(GDK_WATCH);
 	gdk_window_set_cursor(GDK_WINDOW(screen.drawing_area->window), cursor);
 	gdk_cursor_destroy(cursor);
@@ -440,11 +440,11 @@ void render_refresh_rendered_image_on_screen (void) {
 	    screenRenderInfo.displayHeight, -1);
 	    gerbv_render_to_pixmap_using_gdk (mainProject, screen.pixmap, &screenRenderInfo, &screen.selectionInfo,
 	    		&screen.selection_color);	
-	    dprintf("<---- leaving redraw_pixmap.\n");
+	    DPRINTF("<---- leaving redraw_pixmap.\n");
 	}
 	else{
 	    int i;
-	    dprintf("    .... Now try rendering the drawing using cairo .... \n");
+	    DPRINTF("    .... Now try rendering the drawing using cairo .... \n");
 	    /* 
 	     * This now allows drawing several layers on top of each other.
 	     * Higher layer numbers have higher priority in the Z-order.
@@ -460,7 +460,7 @@ void render_refresh_rendered_image_on_screen (void) {
 			screenRenderInfo.displayHeight);
 		    cr= cairo_create(mainProject->file[i]->privateRenderData );
 		    gerbv_render_layer_to_cairo_target (cr, mainProject->file[i], &screenRenderInfo);
-		    dprintf("    .... calling render_image_to_cairo_target on layer %d...\n", i);			
+		    DPRINTF("    .... calling render_image_to_cairo_target on layer %d...\n", i);			
 		    cairo_destroy (cr);
 		}
 	    }


### PR DESCRIPTION
## Summary

- Replace unsafe `#define dprintf if(DEBUG) printf` macro with `#define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)` across all 17 source files
- Add missing braces around single-statement `if`/`else` bodies in `drill.c` (SEI CERT EXP19-C)
- Remove all `goto` patterns in `drill.c`, replacing with structured control flow

## Problem

The `dprintf` macro defined in 16 files as `#define dprintf if(DEBUG) printf` has two issues:

1. **Dangling-else bug** — the unbraced `if` causes `else` to bind incorrectly:
   ```c
   if (error)
       dprintf("bad");    // expands to: if(0) printf("bad");
   else
       handle_ok();       // else binds to if(0), runs unconditionally
   ```

2. **Shadows POSIX `dprintf(3)`** — `dprintf` is a standard function for writing to file descriptors

`main.c` had an even more dangerous variant with two unbraced statements:
```c
#define dprintf printf("%s():  ", __FUNCTION__); printf
```

## Changes

**Commit 1 — `drill.c`**:
- Replace macro definition with safe `DPRINTF(...)` variadic macro
- Rename all call sites from `dprintf()` to `DPRINTF()`
- Add braces to single-statement `if`/`else` bodies
- Remove 3 `goto` patterns, replacing with structured control flow (`parsing_done` flag, `for(;;)` loop, `found_junk` flag)
- Add `[[fallthrough]]` annotation for pre-existing intentional fallthrough

**Commit 2 — remaining 15 files + `main.c`**:
- Same macro replacement across: `gerber.c`, `gerbv.c`, `gerb_file.c`, `gerb_stats.c`, `project.c`, `interface.c`, `callbacks.c`, `render.c`, `attribute.c`, `draw.c`, `draw-gdk.c`, `export-drill.c`, `export-isel-drill.c`, `export-rs274x.c`, `drill_stats.c`, `main.c`

## Acknowledgment

The unsafe macro problem was originally identified by @henrygab in PR #226 (and earlier PR #210), which proposed fixes for `drill.c`. Those PRs were closed without merging. This PR applies the same category of fix using C99 variadic macros (appropriate for the project's C23 standard) and extends it to the full codebase.

## Addresses

- #220 — POSIX `dprintf` shadow / dangling-else hazard
- #216 — Missing braces (SEI CERT EXP19-C) in `drill.c`

## Test plan

- [x] Clean build with zero new warnings (`cmake .. && make -j$(nproc)`)
- [x] Test suite: 94/104 pass (same baseline as `develop`)
- [x] `grep -r '#define dprintf' src/` returns zero results