### PR TITLE
ci: add macos test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
 
 
 jobs:
-  ci:
+  ci-ubuntu-22.04:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -22,7 +22,6 @@ jobs:
         include:
           - coverage: ""
             code_coverage: "" # Always empty, so matrix.code_coverage is always false
-    name: ci
 
     steps:
     - uses: actions/checkout@v6
@@ -146,9 +145,48 @@ jobs:
         GERBV_BUILDBOT_PAT: ${{ secrets.GERBV_BUILDBOT_PAT }}
       if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/develop' && env.GERBV_BUILDBOT_PAT && !matrix.code_coverage }}
 
+  ci-macos:
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Get number of jobs for compiling
+      run: echo "NUM_BUILD_JOBS=$(sysctl -n hw.logicalcpu)" >> $GITHUB_ENV
+
+    - name: Install build dependencies
+      run: |
+        brew install cmake ninja pkgconf gettext gtk+ gtkmm libffi zlib bzip2 libpng expat imagemagick
+        echo "PATH=$(brew --prefix gettext)/bin:${PATH}" >> $GITHUB_ENV
+        mkdir -p "${HOME}/.local/lib/pkgconfig"
+        BZIP_PREFIX="$(brew --prefix bzip2)"
+        BZIP_VERSION="$(brew list --versions bzip2 | awk '{print $2}')"
+        printf '%s\n' \
+          "prefix=${BZIP_PREFIX}" \
+          'exec_prefix=${prefix}' \
+          'libdir=${exec_prefix}/lib' \
+          'includedir=${prefix}/include' \
+          '' \
+          'Name: bzip2' \
+          'Description: bzip2 compression library' \
+          "Version: ${BZIP_VERSION}" \
+          'Libs: -L${libdir} -lbz2' \
+          'Cflags: -I${includedir}' \
+          > "${HOME}/.local/lib/pkgconfig/bzip2.pc"
+        echo "PKG_CONFIG_PATH=${HOME}/.local/lib/pkgconfig:$(brew --prefix libffi)/lib/pkgconfig:$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix bzip2)/lib/pkgconfig:$(brew --prefix libpng)/lib/pkgconfig:$(brew --prefix expat)/lib/pkgconfig:$(brew --prefix)/lib/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+
+    - name: Configure
+      run: cmake -S . -B build -G Ninja
+
+    - name: Build
+      run: cmake --build build -j ${NUM_BUILD_JOBS}
+
+    - name: Run tests
+      continue-on-error: true
+      run: ctest --test-dir build -V
+
   release:
     runs-on: ubuntu-22.04
-    needs: ci
+    needs: [ci-ubuntu-22.04, ci-macos]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,14 +175,14 @@ jobs:
         echo "PKG_CONFIG_PATH=${HOME}/.local/lib/pkgconfig:$(brew --prefix libffi)/lib/pkgconfig:$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix bzip2)/lib/pkgconfig:$(brew --prefix libpng)/lib/pkgconfig:$(brew --prefix expat)/lib/pkgconfig:$(brew --prefix)/lib/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
 
     - name: Configure
-      run: cmake -S . -B build -G Ninja
+      run: cmake --preset macos-clang
 
     - name: Build
-      run: cmake --build build -j ${NUM_BUILD_JOBS}
+      run: cmake --build --preset macos-clang --parallel ${NUM_BUILD_JOBS}
 
     - name: Run tests
       continue-on-error: true
-      run: ctest --test-dir build -V
+      run: ctest --preset macos-clang -V
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
 
 
 jobs:
-  ci-ubuntu-22.04:
+  ci-ubuntu-22-04:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -186,7 +186,7 @@ jobs:
 
   release:
     runs-on: ubuntu-22.04
-    needs: [ci-ubuntu-22.04, ci-macos]
+    needs: [ci-ubuntu-22-04, ci-macos]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,6 +2,7 @@
     "version": 8,
     "include": [
         "cmake/preset/linux-gnu-gcc.json",
+        "cmake/preset/macos-clang.json",
         "cmake/preset/mingw-w64-gcc.json"
     ]
 }

--- a/cmake/preset/macos-clang.json
+++ b/cmake/preset/macos-clang.json
@@ -1,0 +1,35 @@
+{
+    "version": 8,
+    "include": [ "base.json" ],
+    "configurePresets": [
+        {
+            "name": "macos-clang",
+            "inherits": "base",
+            "binaryDir": "build-macos-clang",
+            "cacheVariables": {
+                "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF"
+            },
+            "toolchainFile": "cmake/toolchains/macos-clang.cmake"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "macos-clang",
+            "configurePreset": "macos-clang",
+            "configuration": "Debug"
+        },
+        {
+            "name": "macos-clang-release",
+            "configurePreset": "macos-clang",
+            "configuration": "Release"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "macos-clang",
+            "configurePreset": "macos-clang",
+            "inherits": "base"
+        }
+    ],
+    "packagePresets": []
+}

--- a/cmake/toolchains/macos-clang.cmake
+++ b/cmake/toolchains/macos-clang.cmake
@@ -1,0 +1,11 @@
+#########################
+# macOS clang toolchain #
+#########################
+
+set(CMAKE_SYSTEM_NAME Darwin)
+
+# Use the native Apple Clang toolchain on GitHub macOS runners.
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+add_compile_definitions(_GNU_SOURCE)


### PR DESCRIPTION
Add a native macOS CI smoke build on `macos-15` for CMake/Homebrew validation.

Follow-up to #303.
