### PR TITLE
Add TinyScheme BSD license notice

### DIFF
--- a/.mc/windows_amd64/opt/package.sh
+++ b/.mc/windows_amd64/opt/package.sh
@@ -66,6 +66,7 @@ WEBSITE_DIRECTORY='gerbv.github.io/ci'
 TEMPORARY_DIRECTORY=`"${MKTEMP}" --directory`
 
 "${CP}" 'COPYING' "${TEMPORARY_DIRECTORY}"
+"${CP}" 'COPYING.tinyscheme' "${TEMPORARY_DIRECTORY}"
 "${CP}" 'src/init.scm' "${TEMPORARY_DIRECTORY}"
 "${CP}" 'build/src/Debug/gerbv.exe' "${TEMPORARY_DIRECTORY}"
 "${FIND}" 'build/src/Debug' -name 'libgerbv*.dll' -exec "${CP}" {} "${TEMPORARY_DIRECTORY}" \;

--- a/COPYING.tinyscheme
+++ b/COPYING.tinyscheme
@@ -1,0 +1,29 @@
+Copyright (c) 2000, Dimitrios Souflis
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of Dimitrios Souflis nor the names of the
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ work on providing a mitigation.
 Gerbv and all associated files is placed under the GNU Public License (GPL)
 version 2.0.  See the toplevel [COPYING](COPYING) file for more information.
 
+Gerbv bundles [TinyScheme](https://sourceforge.net/projects/tinyscheme/)
+1.35, which is licensed under the BSD 3-Clause License. See
+[COPYING.tinyscheme](COPYING.tinyscheme) for details.
+
 Programs and associated files are:
 Copyright 2001, 2002 by Stefan Petersen and the respective original authors
 (which are listed on the respective files)


### PR DESCRIPTION
gerbv bundles TinyScheme 1.35 (in `src/scheme.c`, `src/scheme.h`,
`src/scheme-private.h`, `src/opdefines.h`, `src/init.scm`,
`src/dynload.c`, `src/dynload.h`). TinyScheme is licensed under
the BSD 3-Clause License by Dimitrios Souflis, which is
GPL-compatible but requires the license text to be included in
redistributions.

Currently the license text does not appear anywhere in the
repository — `COPYING` only contains GPLv2. This adds:

- **`COPYING.tinyscheme`** — the full BSD 3-Clause License text
  (matching upstream TinyScheme's `COPYING` file)
- **`README.md`** — a note in the License section pointing to the
  new file
- **`.mc/windows_amd64/opt/package.sh`** — include
  `COPYING.tinyscheme` in the Windows release archive alongside
  the existing `COPYING`

Closes #113