### PR TITLE
fix: Put version number into libgerbv.pc correctly.

### DIFF
--- a/src/libgerbv.pc.in
+++ b/src/libgerbv.pc.in
@@ -7,6 +7,6 @@ pkgincludedir=@includedir@/@PACKAGE@
 Name: libgerbv
 Description: Core library for gerbv
 Requires: glib-2.0 gtk+-2.0
-Version: @VERSION@
+Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lgerbv
 Cflags: -I${pkgincludedir}


### PR DESCRIPTION
libgerbv.pc is used by the `pkg-config` tool to get information about the installed version of libgerbv.  It should look something like this:

```
prefix=/usr/local
exec_prefix=${prefix}
libdir=${prefix}/lib
includedir=${prefix}/include
pkgincludedir=${prefix}/include/gerbv

Name: libgerbv
Description: Core library for gerbv
Requires: glib-2.0 gtk+-2.0
Version: 2.11.0
Libs: -L${libdir} -lgerbv
Cflags: -I${pkgincludedir}
```

The `pkg-config` tool can then extract the version of libgerbv by scanning through all the `*.pc` files on the computer.  It works like this:

```
└──> pkg-config libgerbv --modversion
2.11.0
```

However, if the `Version` in that file is missing, it will report nothing.

The autotools programs use a `configure` script in order to configure a make file for building.  (autotools is an older alternative to cmake.)  One of the commands in the configure script might be like this:

```
PKG_CHECK_MODULES([gerbv], [libgerbv >= 2.1.0])
```

To check that the libgerbv version is at least 2.1.0.

However, if the libgerbv.pc file does not have a version, then it will fail and the user will be unable to complete configuration necessary for compilation.

By fixing libgerbv.pc, pkg-config will be able to report the correct version, and then configure will find that version and be able to create a makefile for programs that use libgerbv as a library.