### PR TITLE
fix: Put version number into libgerbv.pc correctly.

### DIFF
--- a/src/libgerbv.pc.in
+++ b/src/libgerbv.pc.in
@@ -7,6 +7,6 @@ pkgincludedir=@includedir@/@PACKAGE@
 Name: libgerbv
 Description: Core library for gerbv
 Requires: glib-2.0 gtk+-2.0
-Version: @VERSION@
+Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lgerbv
 Cflags: -I${pkgincludedir}


### PR DESCRIPTION
Cherry pick to the release branch 2.11 from #337 