### PR TITLE
fix: reset delta_cp_x/y on T-code tool change

### DIFF
--- a/src/drill.c
+++ b/src/drill.c
@@ -1058,6 +1058,8 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	    drill_parse_T_code(fd, state, image, file_line);
 	    state->route_mode = DRILL_G_DRILL;
 	    state->tool_down = FALSE;
+	    state->delta_cp_x = 0;
+	    state->delta_cp_y = 0;
 	    break;
 	case 'V' :
 	    gerb_ungetc (fd);


### PR DESCRIPTION
Addresses point 3 from #335.

Clears `delta_cp_x` and `delta_cp_y` when a T-code tool change is parsed, for consistency with the `route_mode` and `tool_down` resets already present in the same case block.

In practice both fields are already zero by this point (cleared after every arc segment and on tool-up), so this is a defensive hygiene fix rather than a bug fix.