### PR TITLE
fix: document dxflib patches and remove dead tessellation guard

### DIFF
--- a/src/export-dxf.cpp
+++ b/src/export-dxf.cpp
@@ -203,8 +203,6 @@ gerbv_export_dxf_file_from_image(const gchar *file_name,
 						double cy = net->cirseg->cp_y;
 						int steps = (int)(fabs(net->cirseg->angle2 -
 								net->cirseg->angle1) / 2.0) + 1;
-						if (steps < 1)
-							steps = 1;
 						for (int s = 1; s <= steps; s++) {
 							double a = a1 + (a2 - a1) * s / steps;
 							dxf->writeVertex(*dw,

--- a/thirdparty/dxflib/VERSION
+++ b/thirdparty/dxflib/VERSION
@@ -2,3 +2,10 @@ dxflib 3.26.4.0
 Source: github.com/qcad/qcad (src/3rdparty/dxflib/)
 Commit: f3a3459acd690c16f1b2fa80d46d254956d91a49
 Date:   2026-02-20
+
+Patches applied by gerbv:
+  1. dl_dxf.h: remove unused `ret` variable in DL_Dxf::toReal()
+     (caused -Werror build failures)
+  2. dl_codes.h, dl_dxf.h: guard MSVC-only #pragma warning and
+     strcasecmp macro behind _MSC_VER (MinGW defines _WIN32 but
+     uses GCC, so these caused -Werror failures in cross-compilation)


### PR DESCRIPTION
Addresses #334.

- Documents the two patches applied to the bundled dxflib in `thirdparty/dxflib/VERSION`
- Removes the redundant `if (steps < 1) steps = 1` guard in DXF polygon arc tessellation — the `+ 1` already guarantees `steps >= 1`