### PR TITLE
fix: address fopen() patch followups in main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -534,8 +534,13 @@ main(int argc, char *argv[])
 
     attach_console_for_win();
 
-#ifdef G_OS_WIN32
-    /* Convert argv from system codepage to UTF-8 for GLib functions */
+#ifdef WIN32
+    /* Convert argv from system codepage to UTF-8 for GLib functions.
+     * The original argv[i] pointers (owned by the C runtime) are
+     * intentionally overwritten and leaked — the converted strings
+     * must live for the entire process lifetime, and argv is not
+     * freed by the caller.  This block only runs on Windows, so it
+     * will not appear in Linux Valgrind runs. */
     for (i = 0; i < argc; i++) {
         gchar *utf8_arg = g_locale_to_utf8(argv[i], -1, NULL, NULL, NULL);
         if (utf8_arg) {
@@ -956,10 +961,11 @@ main(int argc, char *argv[])
     }
 
     if (logToFileOption) {
-	logFile = fopen(logToFileFilename, "w");
+	logFile = g_fopen(logToFileFilename, "w");
 	if (!logFile) {
-	    fprintf(stderr, "error: cannot open log file '%s'\n",
-		    logToFileFilename);
+	    int saved_errno = errno;
+	    fprintf(stderr, "error: cannot open log file '%s': %s\n",
+		    logToFileFilename, strerror(saved_errno));
 	    exit(1);
 	}
     }


### PR DESCRIPTION
Addresses all four items from #349:

### 1. `logToFileFilename` now uses `g_fopen()`

The `--log` file was still opened with raw `fopen()`, which fails silently on Windows for non-ASCII paths even after the argv UTF-8 conversion from #318. Switched to `g_fopen()` which handles UTF-8 paths correctly on all platforms.

Also preserves `errno` and includes `strerror()` in the error message for better diagnostics.

### 2. `#include <glib/gstdio.h>` is now justified

The include was added in #318 but wasn't actually needed at the time. With the `g_fopen()` call above, it's now required.

### 3. `#ifdef G_OS_WIN32` → `#ifdef WIN32`

Changed to match the existing style used consistently throughout `main.c` (`bind_textdomain_codeset`, `screenRenderInfo.renderType`, etc.). Both macros resolve identically on Windows.

### 4. Argv leak documented

Added a block comment explaining that the `g_locale_to_utf8()` allocations intentionally replace the C runtime's `argv[i]` pointers and are never freed — they must outlive `main()`. The block only compiles on Windows, so it won't appear in Linux Valgrind runs.

Closes #349