### PR TITLE
fix: restore application icon and suppress console window on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,14 @@ target_sources(gerbv-app PRIVATE
 target_compile_definitions(gerbv-app PRIVATE $<$<BOOL:${DEBUG_PRINTOUT}>:DEBUG=1>)
 target_link_libraries(gerbv-app PRIVATE gerbv compilation-flags config)
 add_dependencies(gerbv-app generated)
+if(WIN32)
+    # Embed the application icon via Windows resource file
+    target_sources(gerbv-app PRIVATE gerbv.rc)
+    # Build as a GUI application (no console window).  The existing
+    # attach_console_for_win() in main.c re-attaches to the parent
+    # console when launched from a terminal.
+    target_link_options(gerbv-app PRIVATE -mwindows)
+endif()
 if(APPLE)
     set_target_properties(gerbv-app PROPERTIES
                          INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")

--- a/src/gerbv.rc
+++ b/src/gerbv.rc
@@ -1,1 +1,1 @@
-1 ICON "gerbv_icon.ico"
+1 ICON "../desktop/gerbv_icon.ico"


### PR DESCRIPTION
Fixes two regressions in the Windows build introduced by the autotools-to-CMake migration.

### 1. Missing application icon

The Windows resource file `src/gerbv.rc` was not being compiled into the executable. The old autotools build used `WINDRES` to compile it and link the resulting object, but the CMake build never added it to the target sources.

**Fix:** Add `gerbv.rc` to `gerbv-app` sources when building for Windows. Updated the `.rc` file to use the correct relative path to `desktop/gerbv_icon.ico`.

### 2. Unwanted console window

The `-mwindows` linker flag was not set in the CMake build. Without it, Windows creates a console window for every process. The existing `attach_console_for_win()` function in `main.c` was written assuming `-mwindows` is active — it re-attaches to the parent console when gerbv is launched from a terminal, but that only works when the default console is suppressed.

**Fix:** Add `-mwindows` to the linker options for `gerbv-app` on Windows.

### Changes

- `src/CMakeLists.txt` — Add `WIN32` block with `target_sources` for the `.rc` file and `target_link_options` for `-mwindows`
- `src/gerbv.rc` — Update icon path from `gerbv_icon.ico` to `../desktop/gerbv_icon.ico`

Ref #333