### PR TITLE
fix: use portable font name for layer Modified column

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1642,7 +1642,7 @@ interface_create_gui (int req_width, int req_height)
 
 	renderer = gtk_cell_renderer_text_new ();
 	g_object_set (G_OBJECT (renderer), "foreground", "red", "xalign", 0.5,
-			"family", "Times", "size-points", 12.0, NULL);
+			"family", "Serif", "size-points", 12.0, NULL);
 	column = gtk_tree_view_column_new_with_attributes ("Modified",
 	                                                renderer,
 	                                                "text", 3,


### PR DESCRIPTION
The "Modified" column in the layer list tree view hard-codes `"Times"` as the font family:

```c
g_object_set(G_OBJECT(renderer), "foreground", "red", "xalign", 0.5,
    "family", "Times", "size-points", 12.0, NULL);
```

On Windows this doesn't resolve, producing:
```
couldn't load font "Times 12", falling back to "Sans 12", expect ugly output.
```

Replace with the generic `"Serif"` family name, which Pango/Fontconfig resolve to an appropriate serif font on all platforms — "Times New Roman" on Windows, "DejaVu Serif" on Linux, etc.

One-line change in `src/interface.c`.

Ref #333