### PR TITLE
fix: suppress GdkPixbuf XPM loader warning on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -603,7 +603,33 @@ main(int argc, char *argv[])
 		    NULL);
     g_setenv(settings_schema_env, env_val, TRUE);
     g_free(env_val);
-    
+
+#ifdef WIN32
+    /* Suppress "GdkPixbuf-WARNING: Error loading XPM image loader"
+     * on Windows.  gerbv doesn't use any GdkPixbuf loaders — image
+     * export uses Cairo, and the only XPM usage is inline data via
+     * gdk_pixmap_create_from_xpm_d().  Point GDK_PIXBUF_MODULE_FILE
+     * at an empty cache so GdkPixbuf skips loader enumeration. */
+    if (!g_getenv("GDK_PIXBUF_MODULE_FILE")) {
+	gchar *cache_dir = g_build_filename(
+	    g_get_user_cache_dir(), "gerbv", NULL);
+	g_mkdir_with_parents(cache_dir, 0755);
+	gchar *cache_path = g_build_filename(
+	    cache_dir, "loaders.cache", NULL);
+
+	if (!g_file_test(cache_path, G_FILE_TEST_EXISTS)) {
+	    g_file_set_contents(cache_path,
+		"# GdkPixbuf Image Loader Modules file\n"
+		"# Intentionally empty — gerbv uses no loaders\n",
+		-1, NULL);
+	}
+
+	g_setenv("GDK_PIXBUF_MODULE_FILE", cache_path, FALSE);
+	g_free(cache_path);
+	g_free(cache_dir);
+    }
+#endif
+
     /* set default rendering mode */
 #ifdef WIN32
     /* Cairo seems to render faster on Windows, so use it for default */


### PR DESCRIPTION
## Summary

Suppresses the "GdkPixbuf-WARNING: Error loading XPM image loader" warning on Windows startup.

gerbv doesn't use any GdkPixbuf loaders — image export uses Cairo directly, and the only XPM usage is inline data parsed by `gdk_pixmap_create_from_xpm_d()`. The warning is harmless but confusing to users.

### Approach (reworked)

The original PR shipped an empty `loaders.cache` file via the packaging scripts, but this broke when the Windows build switched from ZIP to NSIS installer (#441, #462).

The reworked fix is entirely in code — at startup (before `gtk_init`), gerbv:
1. Creates `%LOCALAPPDATA%/gerbv/loaders.cache` with an empty GdkPixbuf module list
2. Sets `GDK_PIXBUF_MODULE_FILE` to point at it (only if the env var isn't already set)

This tells GdkPixbuf there are no loaders to enumerate, suppressing the warning. No packaging changes needed — works with both the NSIS installer and the MSYS2 ZIP distribution.

Single file change: `src/main.c`, guarded by `#ifdef WIN32`.

## Test plan

- [x] Builds clean with `-Werror` on Linux
- [x] No new test regressions
- [ ] Verify on Windows: XPM loader warning no longer appears at startup
- [ ] Verify `GDK_PIXBUF_MODULE_FILE` override still works (user-set value is respected)