### PR TITLE
fix: undef DPRINTF before redefining to avoid macOS warning

### DIFF
--- a/src/attribute.c
+++ b/src/attribute.c
@@ -51,6 +51,7 @@
 #include "attribute.h"
 #include "main.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static int auto_uncheck_needed = 0;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -73,6 +73,7 @@
 #endif
 
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /* This default extension should really not be changed, but if it absolutely

--- a/src/draw-gdk.c
+++ b/src/draw-gdk.c
@@ -46,6 +46,7 @@
 #undef round
 #define round(x) ceil((double)(x))
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /*

--- a/src/draw.c
+++ b/src/draw.c
@@ -39,6 +39,7 @@
 #include "common.h"
 #include "selection.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static gboolean draw_do_vector_export_fix(cairo_t *cairoTarget,

--- a/src/drill.c
+++ b/src/drill.c
@@ -57,6 +57,7 @@
 #include "drill_stats.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define MAXL 200

--- a/src/drill_stats.c
+++ b/src/drill_stats.c
@@ -37,6 +37,7 @@
 #include "drill_stats.h"
 #include "gerb_stats.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 

--- a/src/export-drill.c
+++ b/src/export-drill.c
@@ -33,6 +33,7 @@
 
 #include "common.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define round(x) floor(x+0.5)

--- a/src/export-isel-drill.c
+++ b/src/export-isel-drill.c
@@ -39,6 +39,7 @@
 #include "common.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 #define round(x) floor(x+0.5)
 

--- a/src/export-rs274x.c
+++ b/src/export-rs274x.c
@@ -34,6 +34,7 @@
 
 #include "common.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define round(x) floor(x+0.5)

--- a/src/gerb_file.c
+++ b/src/gerb_file.c
@@ -50,6 +50,7 @@
 #include "gerb_file.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 gerb_file_t *

--- a/src/gerb_stats.c
+++ b/src/gerb_stats.c
@@ -35,6 +35,7 @@
 #include "common.h"
 #include "gerb_stats.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /* ------------------------------------------------------- */

--- a/src/gerber.c
+++ b/src/gerber.c
@@ -43,6 +43,7 @@
 #include "amacro.h"
 
 #undef AMACRO_DEBUG
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define A2I(a,b) (((a & 0xff) << 8) + (b & 0xff))

--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -64,6 +64,7 @@
 #include "pick-and-place.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 /** Return string name of gerbv_aperture_type_t aperture type. */

--- a/src/interface.c
+++ b/src/interface.c
@@ -51,6 +51,7 @@
 #include "gerbv_icon.h"
 #include "icons.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static const gchar *gerbv_win_title = N_("Gerbv — gEDA's Gerber Viewer");

--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,7 @@
 #include "project.h"
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 #define NUMBER_OF_DEFAULT_COLORS 18

--- a/src/project.c
+++ b/src/project.c
@@ -104,6 +104,7 @@ static const char * known_versions[] = {
 };
 
 /* DEBUG printing.  #define DEBUG 1 in config.h to use this fcn. */
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 static project_list_t *project_list_top = NULL;

--- a/src/render.c
+++ b/src/render.c
@@ -63,6 +63,7 @@
 #endif
 #include "draw.h"
 
+#undef DPRINTF
 #define DPRINTF(...) do { if (DEBUG) printf(__VA_ARGS__); } while (0)
 
 gerbv_render_info_t screenRenderInfo;


### PR DESCRIPTION
## Summary

- Add `#undef DPRINTF` before every `#define DPRINTF(...)` across all 17 source files
- Fixes `-Wmacro-redefined` warnings on macOS where `CarbonCore/Debugging.h` defines `DPRINTF(x)` (single-arg) and gerbv redefines it as variadic `DPRINTF(...)`
- Follow-up to #320 which introduced the variadic DPRINTF macro

## Test plan

- [ ] macOS CI build should have zero `-Wmacro-redefined` warnings for DPRINTF
- [ ] Linux build unaffected (CarbonCore not present)