### PR TITLE
fix: replace sprintf with snprintf in dxflib

### DIFF
--- a/thirdparty/dxflib/VERSION
+++ b/thirdparty/dxflib/VERSION
@@ -9,3 +9,5 @@ Patches applied by gerbv:
   2. dl_codes.h, dl_dxf.h: guard MSVC-only #pragma warning and
      strcasecmp macro behind _MSC_VER (MinGW defines _WIN32 but
      uses GCC, so these caused -Werror failures in cross-compilation)
+  3. dl_writer_ascii.cpp: replace sprintf with snprintf
+     (sprintf is deprecated on macOS, causes -Wdeprecated-declarations)

--- a/thirdparty/dxflib/dl_writer_ascii.cpp
+++ b/thirdparty/dxflib/dl_writer_ascii.cpp
@@ -61,10 +61,10 @@ bool DL_WriterA::openFailed() const {
 void DL_WriterA::dxfReal(int gc, double value) const {
     char str[256];
     if (version==DL_Codes::AC1009_MIN) {
-        sprintf(str, "%.6lf", value);
+        snprintf(str, sizeof(str), "%.6lf", value);
     }
     else {
-        sprintf(str, "%.16lf", value);
+        snprintf(str, sizeof(str), "%.16lf", value);
     }
     
     // fix for german locale:
@@ -112,7 +112,7 @@ void DL_WriterA::dxfInt(int gc, int value) const {
  */
 void DL_WriterA::dxfHex(int gc, int value) const {
     char str[12];
-    sprintf(str, "%0X", value);
+    snprintf(str, sizeof(str), "%0X", value);
     dxfString(gc, str);
 }
 


### PR DESCRIPTION
## Summary

- Replace 3 `sprintf` calls with `snprintf` in `thirdparty/dxflib/dl_writer_ascii.cpp`
- Fixes `-Wdeprecated-declarations` warnings on macOS where `sprintf` is deprecated
- Documented as patch #3 in `thirdparty/dxflib/VERSION`

## Test plan

- [ ] macOS CI build should have zero `sprintf` deprecation warnings from dxflib
- [ ] Linux build unaffected
- [ ] DXF export functionality unchanged (snprintf with same buffer size)