### PR TITLE
Fix T0 inline parameter parsing and reduce header diagnostic noise

### DIFF
--- a/src/drill.c
+++ b/src/drill.c
@@ -1004,7 +1004,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	case 'R':
 	    if (state->curr_section == DRILL_HEADER) {
 		stats->unknown++;
-		gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_ERROR, -1,
+		gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_NOTE, -1,
 			_("Not allowed 'R' code in the header "
 			    "at line %u in file \"%s\""),
 			file_line, fd->filename);
@@ -1158,7 +1158,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 	    stats->unknown++;
 
 	    if (DRILL_HEADER == state->curr_section) {
-		gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_ERROR, -1,
+		gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_NOTE, -1,
 			_("Undefined code '%s' (0x%x) found in header "
 			    "at line %u in file \"%s\""),
 			gerbv_escape_char(read), read,
@@ -1167,7 +1167,7 @@ parse_drillfile(gerb_file_t *fd, gerbv_HID_Attribute *attr_list, int n_attr, int
 
 		/* Unrecognised crap in the header is thrown away */
 		tmps = get_line(fd);
-		gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_WARNING, -1,
+		gerbv_stats_printf(stats->error_list, GERBV_MESSAGE_NOTE, -1,
 			_("Unrecognised string \"%s\" in header "
 			    "at line %u in file \"%s\""),
 			tmps, file_line, fd->filename);
@@ -1439,7 +1439,26 @@ drill_parse_T_code(gerb_file_t *fd, drill_state_t *state,
     DPRINTF("  Handling tool T%d at line %u\n", tool_num, file_line);
 
     if (tool_num == 0) {
-	return tool_num; /* T00 is a command to unload the drill */
+	/* T0 is nominally an unload-tool command, but some CAD tools
+	   (e.g. ekf2) define T0 with a C diameter parameter in the
+	   header.  Consume any trailing parameters so they don't get
+	   mis-parsed as unknown header codes, then return. */
+	temp = gerb_fgetc(fd);
+	while (temp != EOF && temp != '\n' && temp != '\r') {
+	    if (temp == 'C') {
+		read_double(fd, state->header_number_format,
+			    GERBV_OMIT_ZEROS_TRAILING, state->decimals);
+	    } else if (temp == 'F' || temp == 'S') {
+		gerb_fgetint(fd, NULL);
+	    } else {
+		gerb_ungetc(fd);
+		break;
+	    }
+	    temp = gerb_fgetc(fd);
+	}
+	if (temp == '\n' || temp == '\r')
+	    gerb_ungetc(fd);
+	return tool_num;
     }
 
     if (tool_num < TOOL_MIN || tool_num >= TOOL_MAX) {


### PR DESCRIPTION
## Summary

- Consume inline C/F/S parameters after T0 in drill headers instead of leaving them in the stream where they trigger false "Undefined code" errors
- Downgrade unrecognised vendor-specific header commands (e.g. Veribest `R,H`, `/`) from ERROR to NOTE level, consistent with #306 precedent for unknown machine codes

Fixes gerbv/gerbv#360

## Details

**T0 parameter consumption:** The parser returned immediately on `tool_num == 0`, treating it as an unload command. Files like `T0C0.006` (standard Excellon from ekf2) left `C0.006` in the stream, reported as "Undefined code 'C'". Now the T0 handler consumes any trailing C/F/S parameters before returning.

**Header diagnostic levels:** Unknown header directives don't affect rendering and shouldn't be ERROR. Changed three message sites in the header branch of the default case handler and the R-code-in-header case from ERROR/WARNING to NOTE. Unknown characters in the *data* section remain at ERROR.

## Test plan

- [x] All 4 ekf2 drill files (drill0, drill1, drill20, drill30) parse with zero diagnostic output
- [x] nollezappare ThruHolePlated.ncd produces only `note:` and `warning:` (M71 metric), no `error:`
- [x] Full test suite: 95 pass, 10 fail — unchanged from before (failures are pre-existing image comparison mismatches)
- [x] Build succeeds with no compiler warnings