### PR TITLE
fix: Build authors.c before all locales.

### DIFF
--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -67,6 +67,9 @@ configure_gettext(
  ALL
 )
 add_dependencies(${GETTEXT_TARGET} generated)
+foreach(lang IN LISTS GETTEXT_LANGUAGES)
+    add_dependencies(${GETTEXT_TARGET}-${lang} generated)
+endforeach()
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${GETTEXT_OUTPUT_DIR}/ TYPE LOCALE)
 


### PR DESCRIPTION
Parallel build is failing without this because the `*.pot` files require `config/authors.c`.