### PR TITLE
fix: embed bundled dxflib directly into libgerbv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,11 @@ pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0>=2.6)
 ## DXF support library
 pkg_check_modules(DXF IMPORTED_TARGET dxflib)
 if(NOT DXF_FOUND)
-    # Bundled dxflib (GPL-2+, RibbonSoft/QCAD)
-    add_library(dxflib_bundled STATIC
-        thirdparty/dxflib/dl_dxf.cpp
-        thirdparty/dxflib/dl_writer_ascii.cpp)
-    set_target_properties(dxflib_bundled PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    target_include_directories(dxflib_bundled PUBLIC
-        ${CMAKE_SOURCE_DIR}/thirdparty)
+    # Bundled dxflib sources (GPL-2+, RibbonSoft/QCAD) — compiled directly
+    # into libgerbv so symbols are embedded in the static archive.
+    set(DXFLIB_BUNDLED_SOURCES
+        ${CMAKE_SOURCE_DIR}/thirdparty/dxflib/dl_dxf.cpp
+        ${CMAKE_SOURCE_DIR}/thirdparty/dxflib/dl_writer_ascii.cpp)
     set(DXF_FOUND TRUE)
     set(DXFLIB_BUNDLED TRUE)
 endif()
@@ -63,9 +61,7 @@ target_compile_options(compilation-flags INTERFACE -Wall -Wimplicit-fallthrough 
 target_compile_options(compilation-flags INTERFACE $<$<CONFIG:Debug>:-g3>)
 target_link_libraries(compilation-flags INTERFACE PkgConfig::GLIB PkgConfig::GTK m)
 if(DXF_FOUND)
-    if(DXFLIB_BUNDLED)
-        target_link_libraries(compilation-flags INTERFACE dxflib_bundled)
-    else()
+    if(NOT DXFLIB_BUNDLED)
         target_link_libraries(compilation-flags INTERFACE PkgConfig::DXF)
     endif()
 endif()
@@ -77,6 +73,9 @@ if(APPLE)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_compile_definitions(compilation-flags INTERFACE _GNU_SOURCE)
+endif()
+if(MSVC)
+    target_compile_definitions(compilation-flags INTERFACE _USE_MATH_DEFINES)
 endif()
 
 ## This is installation directory settings. These must be solved later by install target

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,14 @@ target_sources(gerbv PRIVATE
                 tooltable.c)
 if(DXF_FOUND)
     target_sources(gerbv PRIVATE export-dxf.cpp)
+    if(DXFLIB_BUNDLED)
+        target_sources(gerbv PRIVATE ${DXFLIB_BUNDLED_SOURCES})
+        target_include_directories(gerbv PRIVATE ${CMAKE_SOURCE_DIR}/thirdparty)
+        # Suppress warnings in bundled third-party dxflib code that we
+        # don't maintain (GCC flags uninitialized members in DL_HatchEdgeData).
+        set_source_files_properties(${DXFLIB_BUNDLED_SOURCES} PROPERTIES
+            COMPILE_OPTIONS "-Wno-uninitialized;$<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>")
+    endif()
 endif()
 target_link_libraries(gerbv PRIVATE compilation-flags config)
 

--- a/thirdparty/dxflib/VERSION
+++ b/thirdparty/dxflib/VERSION
@@ -11,3 +11,6 @@ Patches applied by gerbv:
      uses GCC, so these caused -Werror failures in cross-compilation)
   3. dl_writer_ascii.cpp: replace sprintf with snprintf
      (sprintf is deprecated on macOS, causes -Wdeprecated-declarations)
+  4. CMake: suppress -Wuninitialized/-Wmaybe-uninitialized on bundled
+     sources (GCC false positive on DL_HatchEdgeData default construction,
+     see #372)


### PR DESCRIPTION
## Summary

When system `dxflib` is absent, the bundled copy is built as a separate `STATIC` library (`dxflib_bundled`) and linked via the `compilation-flags` INTERFACE target. The gerbv executable links fine, but `libgerbv.a` never embeds the dxflib object files — they show up as `*UND*`, breaking downstream consumers like pcb2gcode.

This PR:
- Replaces the separate `dxflib_bundled` STATIC library with a `DXFLIB_BUNDLED_SOURCES` variable
- Adds the bundled sources directly to the `gerbv` library target via `target_sources()`, so symbols are embedded in `libgerbv.a`
- Suppresses `-Wno-uninitialized` on the bundled dxflib files (GCC false positive on `DL_HatchEdgeData` default construction, tracked in #372)
- Defines `_USE_MATH_DEFINES` on MSVC via `compilation-flags` so `M_PI`/`M_1_PI` (used by `DEG2RAD`/`RAD2DEG`) are available under strict ANSI conformance — a header-level define in `gerbv.h` doesn't work because `draw.c`, `draw-gdk.c`, and `export-isel-drill.c` include `<math.h>` before `gerbv.h`

Fixes #366

## Approach

@eyal0's PR #368 identified the same root cause and proposed an `OBJECT` library approach. This PR takes a simpler path: compiling the bundled `.cpp` files directly into `libgerbv` via `target_sources()`, avoiding the extra CMake target entirely.

## Test plan

- [ ] `cmake --build` with no system dxflib → bundled sources compile into libgerbv
- [ ] `nm libgerbv.a | grep dl_dxf` → symbols are defined (`T`), not undefined (`U`)
- [ ] `cmake --build` with system dxflib installed → pkg-config path still works
- [ ] CI passes with `CMAKE_COMPILE_WARNING_AS_ERROR ON` (no dxflib warnings)
- [ ] MSVC build → `M_PI` resolves via the compile definition