### PR TITLE
fix: define _GNU_SOURCE for tinyscheme on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ target_include_directories(tinyscheme_bundled PUBLIC
 target_include_directories(tinyscheme_bundled PRIVATE
     ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(tinyscheme_bundled PRIVATE config)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(tinyscheme_bundled PRIVATE _GNU_SOURCE)
+endif()
 if(Intl_FOUND)
     target_link_libraries(tinyscheme_bundled PRIVATE Intl::Intl)
 endif()


### PR DESCRIPTION
## Summary

Building with GCC 15 on Linux fails because `tinyscheme_bundled` calls `isascii()`, a POSIX function not exposed under `-std=c23` (no extensions). GCC 15 treats implicit function declarations as a hard error in C23.

The `compilation-flags` INTERFACE target already defines `_GNU_SOURCE` on Linux, but `tinyscheme_bundled` links only `config` and never receives it. This adds the definition directly to the tinyscheme target.

Fixes #370

## Test plan

- [ ] `cmake --build` with GCC 15 on Linux — tinyscheme compiles without `-D_GNU_SOURCE` workaround
- [ ] Verify no regression on GCC 14 or Clang