### PR TITLE
Fix missing rotation for circle primitives in GDK renderer

### DIFF
--- a/src/draw-gdk.c
+++ b/src/draw-gdk.c
@@ -91,17 +91,22 @@ gerbv_gdk_draw_prim1(GdkPixmap *pixmap, GdkGC *gc, gerbv_simplified_amacro_t *s,
     const int diameter_idx = 1;
     const int x_offset_idx = 2;
     const int y_offset_idx = 3;
+    const int rotation_idx = 4;
     const gint full_circle = 23360;
     GdkGC *local_gc = gdk_gc_new(pixmap);
     gint dia    = round(fabs(s->parameter[diameter_idx] * scale));
     gint real_x = x - dia / 2;
     gint real_y = y - dia / 2;
+    GdkPoint center;
     GdkColor color;
 
     gdk_gc_copy(local_gc, gc);
 
-    real_x += (int)(s->parameter[x_offset_idx] * (double)scale);
-    real_y -= (int)(s->parameter[y_offset_idx] * (double)scale);
+    center.x = (int)(s->parameter[x_offset_idx] * (double)scale);
+    center.y = -(int)(s->parameter[y_offset_idx] * (double)scale);
+    center = rotate_point(center, s->parameter[rotation_idx]);
+    real_x += center.x;
+    real_y += center.y;
 
     /* Exposure */
     if (s->parameter[exposure_idx] == 0.0) {


### PR DESCRIPTION
## Summary

- `gerbv_gdk_draw_prim1` (circle) was the only GDK macro primitive handler that did not apply `rotate_point()` to its center coordinates
- Before #310, this was masked because `gerb_image.c` pre-rotated the center via `gerbv_rotate_coord()` — the GDK renderer got already-rotated coordinates
- #310 correctly removed that pre-rotation to fix the Cairo double-rotation bug (#233), but exposed that the GDK renderer never had its own rotation handling for circles
- Apply `rotate_point()` to the center offset before translating, matching the pattern used by all other GDK macro primitives (prim4, prim5, prim6, prim7, prim20, prim21, prim22)

## Test plan

- Load the test case from #352 (`1,1,2.59,2,5,19.5` — circle at center 2,5 with 19.5° rotation)
- Switch between Fast (GDK) and Normal (Cairo) rendering — both should now show the circle in the same position on the edge of the square
- Verify selection target matches the rendered position