### PR TITLE
Fix use-after-free SEGV on RS274-X export (#162)

### DIFF
--- a/src/gerb_image.c
+++ b/src/gerb_image.c
@@ -340,6 +340,7 @@ gerbv_image_duplicate_layer (gerbv_layer_t *oldLayer) {
     
     *newLayer = *oldLayer;
     newLayer->name = g_strdup (oldLayer->name);
+    newLayer->next = NULL;
     return newLayer;
 }
 
@@ -349,6 +350,7 @@ gerbv_image_duplicate_state (gerbv_netstate_t *oldState)
 	gerbv_netstate_t *newState = g_new (gerbv_netstate_t, 1);
 
 	*newState = *oldState;
+	newState->next = NULL;
 	return newState;
 }
 


### PR DESCRIPTION
## Summary

Fixes #162 — use-after-free crash when exporting a file as RS274-X.

`gerbv_image_duplicate_layer()` and `gerbv_image_duplicate_state()` shallow-copy their input structs, which retains the original's `next` pointer. When the original image is freed during export the duplicate's `next` becomes dangling, and freeing the duplicate follows it into freed memory.

The fix NULLs `next` after the shallow copy in both functions. Callers in `gerbv_image_duplicate_image()` already build their own linked-list chain via `lastLayer->next = gerbv_image_duplicate_layer(...)`, so the duplicates' `next` pointers are always overwritten — except for the last element, which must be NULL.

## Changes

- `src/gerb_image.c`: Add `newLayer->next = NULL` in `gerbv_image_duplicate_layer()`
- `src/gerb_image.c`: Add `newState->next = NULL` in `gerbv_image_duplicate_state()`

## Test plan

- [x] Builds cleanly with `cmake --preset linux-gnu-gcc && cmake --build build`
- [ ] Existing CI regression tests pass
- [ ] `gerbv --export=rs274x --output=out.grb input.grb` no longer crashes (reproducer from #162)