### PR TITLE
fix: track source pointers in layer/state duplication

### DIFF
--- a/src/gerb_image.c
+++ b/src/gerb_image.c
@@ -390,6 +390,8 @@ gerbv_image_copy_all_nets (gerbv_image_t *sourceImage,
 	 * latest data is: lastLayer, lastState, lastNet. */
 
 	gerbv_net_t *currentNet, *newNet;
+	gerbv_layer_t *srcLayer = NULL;
+	gerbv_netstate_t *srcState = NULL;
 	gerbv_aperture_type_t aper_type;
 	gerbv_aperture_t *aper;
 	gerbv_simplified_amacro_t *sam;
@@ -437,15 +439,21 @@ gerbv_image_copy_all_nets (gerbv_image_t *sourceImage,
 	for (currentNet = sourceImage->netlist; currentNet != NULL;
 			currentNet = currentNet->next) {
 
-		/* Check for any new layers and duplicate them if needed */
-		if (currentNet->layer != lastLayer) {
+		/* Check for any new layers and duplicate them if needed.
+		 * Compare against the source pointer, not the duplicated
+		 * pointer, to avoid creating redundant duplicates when
+		 * consecutive nets share the same layer. */
+		if (currentNet->layer != srcLayer) {
+			srcLayer = currentNet->layer;
 			lastLayer->next =
 				gerbv_image_duplicate_layer (currentNet->layer);
 			lastLayer = lastLayer->next;
 		}
 
-		/* Check for any new states and duplicate them if needed */
-		if (currentNet->state != lastState) {
+		/* Check for any new states and duplicate them if needed.
+		 * Same source-pointer tracking as layers above. */
+		if (currentNet->state != srcState) {
+			srcState = currentNet->state;
 			lastState->next =
 				gerbv_image_duplicate_state (currentNet->state);
 			lastState = lastState->next;


### PR DESCRIPTION
## Summary

Fixes a comparison bug in `gerbv_image_copy_all_nets()` that caused O(n) redundant layer and state allocations during image merging/export.

The existing code compared `currentNet->layer != lastLayer`, but `lastLayer` pointed to a *duplicated* struct — it could never equal a source pointer. Every net therefore created a new duplicate layer and state, even when consecutive nets shared the same source layer/state.

- Track source pointers (`srcLayer`, `srcState`) separately from duplicated pointers
- Compare against source pointers to correctly detect shared layers/states
- Avoids unnecessary `gerbv_image_duplicate_layer()` / `gerbv_image_duplicate_state()` calls

This complements PR #379 (which added `->next = NULL` initialization to the duplicate functions to prevent use-after-free on export).

## Attribution

Extracted from #163 ([@meantaipan](https://github.com/meantaipan)).

## Test plan

- [x] `cmake --preset linux-gnu-gcc && cmake --build build` — clean build
- [x] `ctest -C Debug` — 94/105 pass (11 pre-existing mismatches, unchanged from develop)
- [x] No rendering changes (this fix reduces memory waste, not visual output)