### PR TITLE
Fix memory leaks in layer unload, attribute destroy, and project handling

### DIFF
--- a/src/gerbv.c
+++ b/src/gerbv.c
@@ -360,7 +360,8 @@ gerbv_unload_layer(gerbv_project_t *gerbvProject, int index)
     gint i;
 
     gerbv_destroy_fileinfo (gerbvProject->file[index]);
-    
+    g_free (gerbvProject->file[index]);
+
     /* slide all later layers down to fill the empty slot */
     for (i=index; i<(gerbvProject->last_loaded); i++) {
 	gerbvProject->file[i]=gerbvProject->file[i+1];
@@ -1077,12 +1078,15 @@ gerbv_attribute_destroy_HID_attribute (gerbv_HID_Attribute *attributeList, int n
 {
   int i;
 
-  /* free the string attributes */
+  /* free the string attributes and names */
   for (i = 0 ; i < n_attr ; i++) {
     if ( (attributeList[i].type == HID_String ||
 	  attributeList[i].type == HID_Label) &&
 	attributeList[i].default_val.str_value != NULL) {
       free (attributeList[i].default_val.str_value);
+    }
+    if (attributeList[i].name != NULL) {
+      free (attributeList[i].name);
     }
   }
 
@@ -1106,20 +1110,17 @@ gerbv_attribute_dup (gerbv_HID_Attribute *attributeList, int n_attr)
     exit (1);
   }
 
-  /* copy the attribute list being sure to strdup the strings */
+  /* deep-copy every entry: struct copy first, then strdup name and
+   * string values so the copy owns all its memory independently */
   for (i = 0 ; i < n_attr ; i++) {
+    nl[i] = attributeList[i];
+    nl[i].name = attributeList[i].name ? strdup (attributeList[i].name) : NULL;
 
     if (attributeList[i].type == HID_String ||
 	attributeList[i].type == HID_Label) {
-
-      if (attributeList[i].default_val.str_value != NULL) {
-	nl[i].default_val.str_value = strdup (attributeList[i].default_val.str_value);
-      } else {
-	nl[i].default_val.str_value = NULL;
-      }
-
-    } else {
-      nl[i] = attributeList[i];
+      nl[i].default_val.str_value =
+	  attributeList[i].default_val.str_value
+	      ? strdup (attributeList[i].default_val.str_value) : NULL;
     }
   }
 

--- a/src/project.c
+++ b/src/project.c
@@ -1011,8 +1011,10 @@ read_project_file(char const* filename)
     if ((fd = g_fopen(initfile, "r")) == NULL) {
 	scheme_deinit(sc);
 	GERB_MESSAGE(_("Couldn't open %s (%s)"), initfile, strerror(errno));
+	g_free(initfile);
 	return NULL;
     }
+    g_free(initfile);
 
     /* Force gerbv to input decimals as dots */
     setlocale(LC_NUMERIC, "C");
@@ -1059,10 +1061,11 @@ project_destroy_project_list (project_list_t *projectList){
 	
 	for (tempP = projectList; tempP != NULL; ){
 		tempP2 = tempP->next;
-		
+
 		g_free (tempP->filename);
 		gerbv_attribute_destroy_HID_attribute (tempP->attr_list, tempP->n_attr);
 		tempP->attr_list = NULL;
+		g_free (tempP);
 		tempP = tempP2;
 	}
 }


### PR DESCRIPTION
Fixes four memory leaks found while reviewing #232:

- **`gerbv_unload_layer()`** — After `gerbv_destroy_fileinfo()`, the `fileinfo` struct pointer itself was never freed. `gerbv_destroy_project()` already does both `gerbv_destroy_fileinfo()` + `g_free()`, so this aligns the pattern.
- **`gerbv_attribute_destroy_HID_attribute()`** — The loop frees `default_val.str_value` for string attributes but never frees `name`, which is allocated via `strdup()` at `project.c:727`.
- **`read_project_file()`** — `initfile` is allocated by `gerb_find_file()` but never freed on either the error return path or the normal path after `g_fopen` succeeds.
- **`project_destroy_project_list()`** — The loop frees each node's `filename` and attributes but never frees the node struct itself.

These are standalone bugfixes extracted from @kb-01's work in #232 to make them easier to review and merge independently.

Co-authored-by: kb-01 <kb@sysmikro.com.pl>