### PR TITLE
Fix false-positive Excellon detection in PnP file type checker

### DIFF
--- a/src/pick-and-place.c
+++ b/src/pick-and-place.c
@@ -432,6 +432,7 @@ pick_and_place_check_file_type(gerb_file_t *fd, gboolean *returnFoundBinary)
     int len = 0;
     int i;
     char *letter;
+    char *tmp;
     gboolean found_binary = FALSE;
     gboolean found_G54 = FALSE;
     gboolean found_M0 = FALSE;
@@ -461,19 +462,19 @@ pick_and_place_check_file_type(gerb_file_t *fd, gboolean *returnFoundBinary)
 	    }
 	}
 	
-	if (g_strstr_len(buf, len, "G54")) {
+	if ((tmp = g_strstr_len(buf, len, "G54")) && (tmp - buf < 2)) {
 	    found_G54 = TRUE;
 	}
-	if (g_strstr_len(buf, len, "M00")) {
+	if ((tmp = g_strstr_len(buf, len, "M00")) && (tmp - buf < 2)) {
 	    found_M0 = TRUE;
 	}
-	if (g_strstr_len(buf, len, "M02")) {
+	if ((tmp = g_strstr_len(buf, len, "M02")) && (tmp - buf < 2)) {
 	    found_M2 = TRUE;
 	}
-	if (g_strstr_len(buf, len, "G02")) {
+	if ((tmp = g_strstr_len(buf, len, "G02")) && (tmp - buf < 2)) {
 	    found_G2 = TRUE;
 	}
-	if (g_strstr_len(buf, len, "ADD")) {
+	if ((tmp = g_strstr_len(buf, len, "ADD")) && (tmp - buf < 2)) {
 	    found_ADD = TRUE;
 	}
 	if (g_strstr_len(buf, len, ",")) {


### PR DESCRIPTION
`pick_and_place_check_file_type()` searches for Excellon markers (`G54`, `M00`, `M02`, `G02`, `ADD`) anywhere in each line using `g_strstr_len()`. Component values containing these substrings (e.g., a part value of "M02" or "ADD1085") cause valid PnP files to be misidentified as drill/gerber files, since those markers make the function return `FALSE`.

This adds position checking so these markers are only recognized when they appear at the start of a line (position 0 or 1), where valid Excellon commands always appear. PnP data has these strings embedded in later CSV columns, so checking the position eliminates the false positives.

This partially addresses #119 by improving detection robustness, though it doesn't add explicit `%`-prefix comment skipping (as @KjellMorgenstern's `refactor_pnp` branch approaches). See also #158.

This is a standalone bugfix extracted from @kb-01's work in #232 to make it easier to review and merge independently.

Co-authored-by: kb-01 <kb@sysmikro.com.pl>