### PR TITLE
docs: mention bundled dxflib license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,11 @@ Gerbv bundles [TinyScheme](https://sourceforge.net/projects/tinyscheme/)
 1.35, which is licensed under the BSD 3-Clause License. See
 [thirdparty/tinyscheme/COPYING](thirdparty/tinyscheme/COPYING) for details.
 
+Gerbv bundles [dxflib](https://qcad.org/en/90-dxflib), which is licensed
+under the GNU General Public License (GPL) version 2.0 or later. See
+[thirdparty/dxflib/gpl-2.0greater.txt](thirdparty/dxflib/gpl-2.0greater.txt)
+for details.
+
 Programs and associated files are:
 Copyright 2001, 2002 by Stefan Petersen and the respective original authors
 (which are listed on the respective files)


### PR DESCRIPTION
## Summary

- Add dxflib to the License section of the README, noting it is bundled under GPL-2.0-or-later
- Matches the existing pattern used for the TinyScheme disclosure

dxflib was vendored into `thirdparty/dxflib/` as part of the Fedora 43 / Windows build fixes, but the License section was not updated to mention it.