### PR TITLE
We now have DXF always compiled in so we need to remove all checks if…

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -657,13 +657,11 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 
 		break;
 	case CALLBACKS_SAVE_FILE_DXF:
-#if HAVE_LIBDXFLIB
 		windowTitle = g_strdup_printf (
 			_("Export \"%s\" layer #%d to DXF file as..."),
 			act_file->name, file_index + 1);
 		file_name = g_strconcat (act_file->name, ".dxf", NULL);
 		dir_name =  g_path_get_dirname (act_file->fullPathname);
-#endif
 		break;
 	case CALLBACKS_SAVE_FILE_PNG:
 		windowTitle = g_strdup_printf (
@@ -833,7 +831,6 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 				mainProject, new_file_name, svg_layers);
 		break;
 	case CALLBACKS_SAVE_FILE_DXF:
-#if HAVE_LIBDXFLIB
 		if (gerbv_export_dxf_file_from_image(new_file_name,
 				act_file->image, &act_file->transform)) {
 			GERB_MESSAGE (
@@ -841,7 +838,6 @@ callbacks_generic_save_activate (GtkMenuItem     *menuitem,
 				act_file->name, file_index + 1,
 				new_file_name);
 		}
-#endif
 		break;
 	case CALLBACKS_SAVE_FILE_PNG:
 		if (dpi == 0) {

--- a/src/interface.c
+++ b/src/interface.c
@@ -182,9 +182,7 @@ interface_create_gui (int req_width, int req_height)
 	GtkWidget *menuitem_file_export_menu;
 	GtkWidget *png, *pdf, *svg, *postscript, *geda_pcb;
 	GtkWidget *rs274x, *drill, *idrill, *rs274xm, *drillm;
-#if HAVE_LIBDXFLIB
 	GtkWidget *dxf;
-#endif
 	
 #if GTK_CHECK_VERSION(2,10,0)
 	GtkWidget *print;
@@ -445,12 +443,10 @@ interface_create_gui (int req_width, int req_height)
 	gtk_container_add (GTK_CONTAINER (menuitem_file_export_menu), postscript);
 	gtk_tooltips_set_tip (tooltips, postscript, _("Export visible layers to a PostScript file"), NULL);
 
-#if HAVE_LIBDXFLIB
 	dxf = gtk_menu_item_new_with_mnemonic (_("D_XF..."));
 	gtk_container_add (GTK_CONTAINER (menuitem_file_export_menu), dxf);
 	gtk_tooltips_set_tip (tooltips, dxf,
 			_("Export active layer to a DXF file"), NULL);
-#endif
 
 	gtk_container_add (GTK_CONTAINER (menuitem_file_export_menu),
 			gtk_separator_menu_item_new ());
@@ -1376,11 +1372,9 @@ interface_create_gui (int req_width, int req_height)
 	g_signal_connect ((gpointer) geda_pcb, "activate",
 	                  G_CALLBACK (callbacks_generic_save_activate),
 	                  (gpointer) CALLBACKS_SAVE_FILE_GEDA_PCB);
-#if HAVE_LIBDXFLIB
 	g_signal_connect ((gpointer) dxf, "activate",
 	                  G_CALLBACK (callbacks_generic_save_activate),
 	                  (gpointer) CALLBACKS_SAVE_FILE_DXF);
-#endif
 	g_signal_connect ((gpointer) rs274x, "activate",
 	                  G_CALLBACK (callbacks_generic_save_activate),
 	                  (gpointer) CALLBACKS_SAVE_FILE_RS274X);

--- a/src/main.c
+++ b/src/main.c
@@ -511,9 +511,7 @@ main(int argc, char *argv[])
 	EXP_TYPE_RS274X,
 	EXP_TYPE_DRILL,
 	EXP_TYPE_IDRILL,
-#ifdef HAVE_LIBDXFLIB
 	EXP_TYPE_DXF,
-#endif
     };
     enum exp_type exportType = EXP_TYPE_NONE;
     const char *export_type_names[] = {
@@ -524,9 +522,7 @@ main(int argc, char *argv[])
 	"rs274x",
 	"drill",
 	"idrill",
-#ifdef HAVE_LIBDXFLIB
 	"dxf",
-#endif
 	NULL
     };
     const gchar *export_def_file_names[] = {
@@ -537,9 +533,7 @@ main(int argc, char *argv[])
 	"output.gbx",
 	"output.cnc",
 	"output.ncp",
-#ifdef HAVE_LIBDXFLIB
 	"output.dxf",
-#endif
 	NULL
     };
 
@@ -1200,9 +1194,7 @@ main(int argc, char *argv[])
 	case EXP_TYPE_RS274X:
 	case EXP_TYPE_DRILL:
 	case EXP_TYPE_IDRILL:
-#ifdef HAVE_LIBDXFLIB
 	case EXP_TYPE_DXF:
-#endif
 	    if (!mainProject->file[0]->image) {
 		fprintf(stderr, _("A valid file was not loaded.\n"));
 		if (logFile)
@@ -1234,12 +1226,10 @@ main(int argc, char *argv[])
 		gerbv_export_isel_drill_file_from_image (exportFilename,
 			exportImage, &mainProject->file[0]->transform);
 		break;
-#ifdef HAVE_LIBDXFLIB
 	    case EXP_TYPE_DXF:
 		gerbv_export_dxf_file_from_image(exportFilename,
 			exportImage, &mainProject->file[0]->transform);
 		break;
-#endif
 	    default:
 		break;
 	    }
@@ -1497,11 +1487,7 @@ gerbv_print_help(void)
 
 #ifdef HAVE_GETOPT_LONG
 	printf(_(
-#ifdef HAVE_LIBDXFLIB
 "  -x, --export=<png|pdf|ps|svg|rs274x|drill|idrill|dxf>\n"
-#else
-"  -x, --export=<png|pdf|ps|svg|rs274x|drill|idrill>\n"
-#endif
 "                          Export a rendered picture to a file with\n"
 "                          the specified format.\n"));
 	printf(_(
@@ -1514,11 +1500,7 @@ gerbv_print_help(void)
 	printf(_(
 "  -x<png|pdf|ps|svg|      Export a rendered picture to a file with\n"
 "     rs274x|drill|        the specified format.\n"
-#ifdef HAVE_LIBDXFLIB
 "     idrill|dxf>\n"
-#else
-"     idrill>\n"
-#endif
 ));
 	printf(_(
 "      --svg-layers       Export visible layers as Inkscape SVG layers.\n"


### PR DESCRIPTION
… it is compiled in

@rampageservices noticed that when I merged in PR #374 all DXF support disappeared since I also removed the flag. So this is to remove all the checks if DXF is compiled in or not.

Closes #387 