### PR TITLE
Pipeline fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,30 +100,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: gerbv-lcov.info
 
-    - name: Rebuild Fedora 43
-      if: "!matrix.code_coverage"
-      run: npx --package mini-cross@0.15.2 mc --no-tty fedora_43 .mc/rebuild.sh
-
-    - name: Rebuild Ubuntu 22.04
-      if: "!matrix.code_coverage"
-      run: npx --package mini-cross@0.15.2 mc --no-tty ubuntu_22.04 .mc/rebuild.sh
-
-    - name: Rebuild Debian 13
-      if: "!matrix.code_coverage"
-      run: npx --package mini-cross@0.15.2 mc --no-tty debian_13 .mc/rebuild.sh
-
-    - name: Rebuild Windows amd64
-      if: "!matrix.code_coverage"
-      run: npx --package mini-cross@0.15.2 mc --no-tty windows_amd64 .mc/rebuild-win.sh
-
-    - name: Upload executable artifacts
-      if: "!matrix.code_coverage"
-      uses: actions/upload-artifact@v6
-      with:
-        name: gerbv
-        path: gerbv.github.io/ci/gerbv*
-        if-no-files-found: error
-
     - name: Rebuild gerbv.github.io
       if: ${{ github.ref == 'refs/heads/develop' && !matrix.code_coverage }}
       run: |
@@ -144,6 +120,66 @@ jobs:
       env:
         GERBV_BUILDBOT_PAT: ${{ secrets.GERBV_BUILDBOT_PAT }}
       if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/develop' && env.GERBV_BUILDBOT_PAT && !matrix.code_coverage }}
+
+  ci-fedora:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Rebuild Fedora 43
+      run: npx --package mini-cross@0.15.2 mc --no-tty fedora_43 .mc/rebuild.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: gerbv-fedora
+        path: gerbv.github.io/ci/gerbv*
+        if-no-files-found: error
+
+  ci-ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Rebuild Ubuntu 22.04
+      run: npx --package mini-cross@0.15.2 mc --no-tty ubuntu_22.04 .mc/rebuild.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: gerbv-ubuntu
+        path: gerbv.github.io/ci/gerbv*
+        if-no-files-found: error
+
+  ci-debian:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Rebuild Debian 13
+      run: npx --package mini-cross@0.15.2 mc --no-tty debian_13 .mc/rebuild.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: gerbv-debian
+        path: gerbv.github.io/ci/gerbv*
+        if-no-files-found: error
+
+  ci-windows_amd64-cross:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Rebuild Windows amd64 cross compilation
+      run: npx --package mini-cross@0.15.2 mc --no-tty windows_amd64 .mc/rebuild-win.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: gerbv-windows_amd64
+        path: gerbv.github.io/ci/gerbv*
+        if-no-files-found: error
 
   ci-macos:
     runs-on: macos-15
@@ -186,7 +222,7 @@ jobs:
 
   release:
     runs-on: ubuntu-22.04
-    needs: [ci-ubuntu-22-04, ci-macos]
+    needs: [ci-ubuntu-22-04, ci-fedora, ci-debian, ci-ubuntu, ci-windows_amd64-cross, ci-macos]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -194,8 +230,9 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v6
         with:
-          name: gerbv
+          pattern: gerbv-*
           path: artifacts/
+          merge-multiple: true
 
       - name: Rename artifacts to use version tag
         run: |

--- a/.mc/debian_13/debian_13.yaml
+++ b/.mc/debian_13/debian_13.yaml
@@ -9,7 +9,6 @@ install:
  - pkg-config
 
  # Runtime dependencies
- - libdxflib-dev
  - libgtk2.0-dev
  - libcairo2-dev
 

--- a/.mc/fedora_43/fedora_43.yaml
+++ b/.mc/fedora_43/fedora_43.yaml
@@ -13,7 +13,6 @@ install:
  # Runtime dependencies
  - cairo-devel
  - gtk2-devel
- # Note: libdxflib removed from Fedora 43, DXF support will be disabled
 
  # Test dependencies
  - ImageMagick

--- a/.mc/ubuntu_22.04/ubuntu_22.04.yaml
+++ b/.mc/ubuntu_22.04/ubuntu_22.04.yaml
@@ -11,7 +11,6 @@ install:
  - gpg
 
  # Runtime dependencies
- - libdxflib-dev
  - libgtk2.0-dev
  - libcairo2-dev
 


### PR DESCRIPTION
In the builds that previously included DXF-lib have now removed that dependency to at least get one less package to install during builds.

Also more parallelization of CI builds to speed up the builds. It now builds every package separately and in parallel.