### PR TITLE
Implement our own local version of isascii() for tinyscheme.

### DIFF
--- a/thirdparty/tinyscheme/GERBV_PATCHES
+++ b/thirdparty/tinyscheme/GERBV_PATCHES
@@ -5,3 +5,6 @@ License: BSD 3-Clause (see COPYING)
 
 Bundled with gerbv for the project file parser (project.c).
 Used as an embedded interpreter — not built standalone.
+
+The following known patches added so far:
+1. The isascii() function in scheme.c replaced by our own local version

--- a/thirdparty/tinyscheme/scheme.c
+++ b/thirdparty/tinyscheme/scheme.c
@@ -266,11 +266,12 @@ INTERFACE INLINE void setimmutable(pointer p) { typeflag(p) |= T_IMMUTABLE; }
 #define cddddr(p)        cdr(cdr(cdr(cdr(p))))
 
 #if USE_CHAR_CLASSIFIERS
-static INLINE int Cisalpha(int c) { return isascii(c) && isalpha(c); }
-static INLINE int Cisdigit(int c) { return isascii(c) && isdigit(c); }
-static INLINE int Cisspace(int c) { return isascii(c) && isspace(c); }
-static INLINE int Cisupper(int c) { return isascii(c) && isupper(c); }
-static INLINE int Cislower(int c) { return isascii(c) && islower(c); }
+static INLINE int isascii_local(int c) { return (c >= 0) && (c < 128); }
+static INLINE int Cisalpha(int c) { return isascii_local(c) && isalpha(c); }
+static INLINE int Cisdigit(int c) { return isascii_local(c) && isdigit(c); }
+static INLINE int Cisspace(int c) { return isascii_local(c) && isspace(c); }
+static INLINE int Cisupper(int c) { return isascii_local(c) && isupper(c); }
+static INLINE int Cislower(int c) { return isascii_local(c) && islower(c); }
 #endif
 
 #if USE_ASCII_NAMES


### PR DESCRIPTION
isascii() is obsoleted a long time ago and GCC15 have removed it completely.

Closes #370 