### PR TITLE
Move some toplevel definitions to respective toolchain files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,6 @@ target_link_libraries(compilation-flags INTERFACE PkgConfig::GLIB PkgConfig::GTK
 if(Intl_FOUND)
     target_link_libraries(compilation-flags INTERFACE Intl::Intl)
 endif()
-if(APPLE)
-    target_compile_definitions(compilation-flags INTERFACE QUARTZ)
-endif()
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_compile_definitions(compilation-flags INTERFACE _GNU_SOURCE)
-endif()
 
 ## This is installation directory settings. These must be solved later by install target
 target_compile_definitions(compilation-flags INTERFACE "GERBV_DATADIR=\"${DATADIR}\"")

--- a/cmake/toolchains/macos-clang.cmake
+++ b/cmake/toolchains/macos-clang.cmake
@@ -8,4 +8,4 @@ set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)
 
-add_compile_definitions(_GNU_SOURCE)
+add_compile_definitions(_GNU_SOURCE QUARTZ)


### PR DESCRIPTION
Top-level definitions for specific architectures should go into toolchain files. It is not always so though.