### PR TITLE
fix: Define M_PI, M_PI_2, and M_1_PI.

### DIFF
--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -78,6 +78,16 @@ For help with using the standalone Gerbv software, please refer to the man page
 # include <cairo.h>
 #endif
 
+#ifndef M_PI
+# define M_PI		3.14159265358979323846	/* pi */
+#endif
+#ifndef M_PI_2
+# define M_PI_2		1.57079632679489661923	/* pi/2 */
+#endif
+#ifndef M_1_PI
+# define M_1_PI		0.31830988618379067154	/* 1/pi */
+#endif
+
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
They are non-standard and not necessarily defined already.

This fixes #392.