### PR TITLE
ci: fix Windows regression test runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,6 +243,7 @@ jobs:
           gtk2:p
           gtkmm:p
           gettext-tools:p
+          imagemagick:p
 
     - name: Configure
       run: cmake --preset msys2-ucrt64-gcc

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -76,6 +76,17 @@ option(USE_INTERFACE "Use extension interface of Scheme interpreter" ON)
 configure_file(config.h.in config.h @ONLY)
 
 set(GENERATOR_SCRIPT_DIR ${CMAKE_SOURCE_DIR}/cmake/generate)
+
+# Generate at configure time so xgettext can find them
+execute_process(
+    COMMAND ${CMAKE_COMMAND}
+            -DINPUT_BUGS=${CMAKE_SOURCE_DIR}/BUGS
+            -DOUTPUT_BUGS=${CMAKE_CURRENT_BINARY_DIR}/bugs.c
+            -DINPUT_AUTHORS=${CMAKE_SOURCE_DIR}/AUTHORS
+            -DOUTPUT_AUTHORS=${CMAKE_CURRENT_BINARY_DIR}/authors.c
+            -P ${GENERATOR_SCRIPT_DIR}/generate_headers.cmake
+)
+
 add_custom_command(
     OUTPUT bugs.c authors.c
     COMMAND ${CMAKE_COMMAND}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,5 +9,14 @@ add_test(
 # CMake 3.28+ required for generator expressions in test properties (already required by project)
 set_tests_properties(gerbv_regression_tests PROPERTIES
     ENVIRONMENT "GERBV=$<TARGET_FILE:gerbv-app>;GERBV_SCHEMEINIT=${CMAKE_SOURCE_DIR}/thirdparty/tinyscheme"
-    ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:$<TARGET_FILE_DIR:gerbv>"
 )
+
+if(WIN32)
+    set_tests_properties(gerbv_regression_tests PROPERTIES
+        ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:gerbv>"
+    )
+else()
+    set_tests_properties(gerbv_regression_tests PROPERTIES
+        ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:$<TARGET_FILE_DIR:gerbv>"
+    )
+endif()

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -148,13 +148,22 @@ GERBV_DEFAULT_FLAGS=${GERBV_DEFAULT_FLAGS:---export=png --window=640x480}
 # Source directory
 srcdir=${srcdir:-.}
 
+# Detect ImageMagick version and set command syntax.
+# IMv7 uses "magick <subcommand>" instead of bare command names.
+# This also avoids the Windows convert.exe collision.
+if command -v magick >/dev/null 2>&1; then
+    _IM="magick "
+else
+    _IM=""
+fi
+
 # various ImageMagick tools
-IM_ANIMATE=${IM_ANIMATE:-animate}
-IM_COMPARE=${IM_COMPARE:-compare}
-IM_COMPOSITE=${IM_COMPOSITE:-composite}
-IM_CONVERT=${IM_CONVERT:-convert}
-IM_DISPLAY=${IM_DISPLAY:-display}
-IM_MONTAGE=${IM_MONTAGE:-montage}
+IM_ANIMATE=${IM_ANIMATE:-${_IM}animate}
+IM_COMPARE=${IM_COMPARE:-${_IM}compare}
+IM_COMPOSITE=${IM_COMPOSITE:-${_IM}composite}
+IM_CONVERT=${IM_CONVERT:-${_IM}convert}
+IM_DISPLAY=${IM_DISPLAY:-${_IM}display}
+IM_MONTAGE=${IM_MONTAGE:-${_IM}montage}
 
 # golden directories
 INDIR=${INDIR:-${srcdir}/inputs}

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -149,19 +149,21 @@ GERBV_DEFAULT_FLAGS=${GERBV_DEFAULT_FLAGS:---export=png --window=640x480}
 srcdir=${srcdir:-.}
 
 # Detect ImageMagick version and set command syntax.
-# IMv7 uses "magick <subcommand>" instead of bare command names.
-# This also avoids the Windows convert.exe collision.
+# IMv7 merged "convert" into "magick" and uses "magick <subcommand>"
+# for all other tools.  This also avoids the Windows convert.exe collision.
 if command -v magick >/dev/null 2>&1; then
     _IM="magick "
+    _IM_CONVERT="magick"
 else
     _IM=""
+    _IM_CONVERT="convert"
 fi
 
 # various ImageMagick tools
 IM_ANIMATE=${IM_ANIMATE:-${_IM}animate}
 IM_COMPARE=${IM_COMPARE:-${_IM}compare}
 IM_COMPOSITE=${IM_COMPOSITE:-${_IM}composite}
-IM_CONVERT=${IM_CONVERT:-${_IM}convert}
+IM_CONVERT=${IM_CONVERT:-${_IM_CONVERT}}
 IM_DISPLAY=${IM_DISPLAY:-${_IM}display}
 IM_MONTAGE=${IM_MONTAGE:-${_IM}montage}
 


### PR DESCRIPTION
## Summary

Follow-up to #378. Fixes the remaining cross-platform CI issues from the Windows regression test work.

### Changes

1. **Fix xgettext configure-time race** (`config/CMakeLists.txt`)
   - On clean CI checkouts, `Gettext_helpers.cmake` runs `xgettext` at configure time, but `authors.c`/`bugs.c` don't exist yet (they're generated at build time)
   - Add `execute_process()` to generate these files at configure time using the same `generate_headers.cmake` script — pure CMake `file()` commands, no external tools
   - The build-time `add_custom_command` stays for incremental rebuilds

2. **Fix IMv7 `convert` deprecation** (`test/run_tests.sh`)
   - All CI platforms ship ImageMagick v7 where `convert`, `compare`, etc. are deprecated in favor of `magick` subcommands
   - On Windows, bare `convert` also collides with the Windows `convert.exe` disk utility
   - Auto-detect IMv7 via `command -v magick` and prefix all IM tool invocations accordingly
   - `convert` is a special case — it was merged into `magick` itself, so it maps to bare `magick` (not `magick convert`, which still emits a deprecation warning)
   - Environment variable overrides (`IM_COMPARE`, etc.) still work

### Previous changes (from earlier commits)

- Add `imagemagick:p` to the MSYS2 UCRT64 package list in `ci.yaml`
- Use `PATH` instead of `LD_LIBRARY_PATH` on Windows in `test/CMakeLists.txt`

### Test results

- **94/105 tests pass on Windows** — 11 rendering differences from cairo-win32 vs cairo-xlib (expected, handled by `continue-on-error: true`)
- Ubuntu and macOS CI jobs remain unaffected

## Test plan

- [x] Windows CI job runs regression tests without `command not found` errors
- [x] 94/105 tests pass on Windows (11 rendering differences expected)
- [x] Ubuntu and macOS CI jobs remain unaffected
- [x] No xgettext warnings on clean configure
- [x] No IMv7 deprecation warnings on any platform