### PR TITLE
ci: add artifact upload for MSYS2 and macOS jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,6 +185,8 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Get number of jobs for compiling
       run: echo "NUM_BUILD_JOBS=$(sysctl -n hw.logicalcpu)" >> $GITHUB_ENV
@@ -220,6 +222,16 @@ jobs:
       continue-on-error: true
       run: ctest --preset macos-clang -V
 
+    - name: Package
+      run: bash .mc/package-macos.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: gerbv-macos
+        path: gerbv.github.io/ci/gerbv*
+        if-no-files-found: error
+
   ci-windows:
     runs-on: windows-latest
     defaults:
@@ -235,6 +247,7 @@ jobs:
       with:
         msystem: UCRT64
         update: true
+        install: zip
         pacboy: >-
           toolchain:p
           cmake:p
@@ -254,6 +267,16 @@ jobs:
     - name: Run tests
       continue-on-error: true
       run: ctest --preset msys2-ucrt64-gcc -V
+
+    - name: Package
+      run: bash .mc/package-msys2.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        name: gerbv-windows-msys2
+        path: gerbv.github.io/ci/gerbv*
+        if-no-files-found: error
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,7 +247,7 @@ jobs:
       with:
         msystem: UCRT64
         update: true
-        install: zip
+        install: git zip
         pacboy: >-
           toolchain:p
           cmake:p

--- a/.mc/package-macos.sh
+++ b/.mc/package-macos.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Builds an archive containing a gerbv binary distribution for macOS systems
+#
+# Uses otool to iteratively discover dylib dependencies from Homebrew,
+# filtering out macOS system libraries.
+#
+# @warning Expects working directory to be set to project root
+
+
+# Validate arguments
+RELEASE_OS="macOS"
+
+
+# Validate environment
+CP=`command -v cp`
+FIND=`command -v find`
+GIT=`command -v git`
+OTOOL=`command -v otool`
+ZIP=`command -v zip`
+
+if [ ! -x "${CP}" ]; then
+	(>&2 echo "\`cp' missing")
+	exit 1
+fi
+
+if [ ! -x "${FIND}" ]; then
+	(>&2 echo "\`find' missing")
+	exit 1
+fi
+
+if [ ! -x "${GIT}" ]; then
+	(>&2 echo "\`git' missing")
+	exit 1
+fi
+
+if [ ! -x "${OTOOL}" ]; then
+	(>&2 echo "\`otool' missing")
+	exit 1
+fi
+
+if [ ! -x "${ZIP}" ]; then
+	(>&2 echo "\`zip' missing")
+	exit 1
+fi
+
+
+# Gather information about current build
+set -e
+
+RELEASE_COMMIT=`"${GIT}" rev-parse HEAD`
+RELEASE_COMMIT_SHORT="${RELEASE_COMMIT:0:6}"
+RELEASE_DATE=`date +%Y-%m-%d`
+
+
+# Copy files to be released into temporary directory
+WEBSITE_DIRECTORY='gerbv.github.io/ci'
+TEMPORARY_DIRECTORY=`mktemp -d`
+
+"${CP}" 'COPYING' "${TEMPORARY_DIRECTORY}"
+"${CP}" 'thirdparty/tinyscheme/COPYING' "${TEMPORARY_DIRECTORY}/COPYING.tinyscheme"
+"${CP}" 'thirdparty/tinyscheme/init.scm' "${TEMPORARY_DIRECTORY}"
+"${CP}" 'build-macos-clang/src/Debug/gerbv' "${TEMPORARY_DIRECTORY}"
+"${FIND}" 'build-macos-clang/src/Debug' -name 'libgerbv*.dylib' -exec "${CP}" {} "${TEMPORARY_DIRECTORY}" \;
+
+# Iteratively discover dylib dependencies using otool, filtering out macOS
+# system libraries. otool -L outputs lines like:
+#
+#     /opt/homebrew/lib/libgtk-x11-2.0.0.dylib (compatibility ...)
+#     /usr/lib/libSystem.B.dylib (compatibility ...)
+#
+# We keep only non-system libraries and resolve them recursively until no new
+# dependencies are found. A marker file communicates across the pipe subshell.
+while true; do
+	for bin in "${TEMPORARY_DIRECTORY}"/*; do
+		[ -f "${bin}" ] || continue
+		"${OTOOL}" -L "${bin}" 2>/dev/null | tail -n +2 | awk '{print $1}' | while read -r dep; do
+			case "${dep}" in
+				/usr/lib/*|/System/*|@rpath/*|@executable_path/*|@loader_path/*) continue ;;
+			esac
+			dep_name=`basename "${dep}"`
+			if [ ! -f "${TEMPORARY_DIRECTORY}/${dep_name}" ] && [ -f "${dep}" ]; then
+				"${CP}" "${dep}" "${TEMPORARY_DIRECTORY}/"
+				touch "${TEMPORARY_DIRECTORY}/.found_new"
+			fi
+		done
+	done
+	if [ -f "${TEMPORARY_DIRECTORY}/.found_new" ]; then
+		rm "${TEMPORARY_DIRECTORY}/.found_new"
+	else
+		break
+	fi
+done
+
+
+# Create archive and auxiliary files
+mkdir -p "${WEBSITE_DIRECTORY}"
+RELEASE_FILENAME="gerbv_${RELEASE_DATE}_${RELEASE_COMMIT_SHORT}_(${RELEASE_OS}).zip"
+
+"${FIND}" "${TEMPORARY_DIRECTORY}" -type f -exec "${ZIP}" --junk-paths "${WEBSITE_DIRECTORY}/${RELEASE_FILENAME}" {} \;
+
+echo "${RELEASE_COMMIT}"	> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_COMMIT"
+echo "${RELEASE_COMMIT_SHORT}"	> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_COMMIT_SHORT"
+echo "${RELEASE_DATE}"		> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_DATE"
+echo "${RELEASE_FILENAME}"	> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_FILENAME"

--- a/.mc/package-msys2.sh
+++ b/.mc/package-msys2.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# Builds an archive containing a gerbv binary distribution for Windows MSYS2
+# UCRT64 systems
+#
+# Uses ldd to discover runtime DLL dependencies from the UCRT64 environment,
+# rather than copying all DLLs (which would include hundreds of unnecessary
+# packages).
+#
+# @warning Expects working directory to be set to project root
+
+
+# Validate arguments
+RELEASE_OS="Windows MSYS2 UCRT64"
+
+
+# Validate environment
+CP=`command -v cp`
+DATE=`command -v date`
+FIND=`command -v find`
+GIT=`command -v git`
+LDD=`command -v ldd`
+MKDIR=`command -v mkdir`
+MKTEMP=`command -v mktemp`
+ZIP=`command -v zip`
+
+if [ ! -x "${CP}" ]; then
+	(>&2 echo "\`cp' missing")
+	exit 1
+fi
+
+if [ ! -x "${DATE}" ]; then
+	(>&2 echo "\`date' missing")
+	exit 1
+fi
+
+if [ ! -x "${FIND}" ]; then
+	(>&2 echo "\`find' missing")
+	exit 1
+fi
+
+if [ ! -x "${GIT}" ]; then
+	(>&2 echo "\`git' missing")
+	exit 1
+fi
+
+if [ ! -x "${LDD}" ]; then
+	(>&2 echo "\`ldd' missing")
+	exit 1
+fi
+
+if [ ! -x "${MKDIR}" ]; then
+	(>&2 echo "\`mkdir' missing")
+	exit 1
+fi
+
+if [ ! -x "${MKTEMP}" ]; then
+	(>&2 echo "\`mktemp' missing")
+	exit 1
+fi
+
+if [ ! -x "${ZIP}" ]; then
+	(>&2 echo "\`zip' missing")
+	exit 1
+fi
+
+
+# Gather information about current build
+set -e
+
+RELEASE_COMMIT=`"${GIT}" rev-parse HEAD`
+RELEASE_COMMIT_SHORT="${RELEASE_COMMIT:0:6}"
+RELEASE_DATE=`"${DATE}" --rfc-3339=date`
+
+
+# Copy files to be released into temporary directory
+WEBSITE_DIRECTORY='gerbv.github.io/ci'
+TEMPORARY_DIRECTORY=`"${MKTEMP}" --directory`
+
+"${CP}" 'COPYING' "${TEMPORARY_DIRECTORY}"
+"${CP}" 'thirdparty/tinyscheme/COPYING' "${TEMPORARY_DIRECTORY}/COPYING.tinyscheme"
+"${CP}" 'thirdparty/tinyscheme/init.scm' "${TEMPORARY_DIRECTORY}"
+"${CP}" 'build/src/Debug/gerbv.exe' "${TEMPORARY_DIRECTORY}"
+"${FIND}" 'build/src/Debug' -name 'libgerbv*.dll' -exec "${CP}" {} "${TEMPORARY_DIRECTORY}" \;
+
+# Discover runtime DLL dependencies using ldd, filtering out Windows system
+# DLLs. ldd in MSYS2 outputs lines like:
+#
+#     libglib-2.0-0.dll => /ucrt64/bin/libglib-2.0-0.dll (0x7ff...)
+#     KERNEL32.dll => /c/Windows/System32/KERNEL32.dll (0x7ff...)
+#
+# We keep only DLLs from /ucrt64/ (the MSYS2 UCRT64 runtime libraries).
+BINARIES="${TEMPORARY_DIRECTORY}/gerbv.exe"
+for dll in "${TEMPORARY_DIRECTORY}"/libgerbv*.dll; do
+	[ -f "${dll}" ] && BINARIES="${BINARIES} ${dll}"
+done
+
+"${LDD}" ${BINARIES} \
+	| grep -i '=> /ucrt64/' \
+	| awk '{print $3}' \
+	| sort -u \
+	| while read -r dll_path; do
+		"${CP}" "${dll_path}" "${TEMPORARY_DIRECTORY}"
+	done
+
+
+# Create archive and auxiliary files
+"${MKDIR}" -p "${WEBSITE_DIRECTORY}"
+RELEASE_FILENAME="gerbv_${RELEASE_DATE}_${RELEASE_COMMIT_SHORT}_(${RELEASE_OS}).zip"
+
+"${FIND}" "${TEMPORARY_DIRECTORY}" -type f -exec "${ZIP}" --junk-paths "${WEBSITE_DIRECTORY}/${RELEASE_FILENAME}" {} \;
+
+echo "${RELEASE_COMMIT}"	> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_COMMIT"
+echo "${RELEASE_COMMIT_SHORT}"	> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_COMMIT_SHORT"
+echo "${RELEASE_DATE}"		> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_DATE"
+echo "${RELEASE_FILENAME}"	> "${WEBSITE_DIRECTORY}/${RELEASE_OS}.RELEASE_FILENAME"


### PR DESCRIPTION
## Summary

- Add MSYS2 UCRT64 packaging script (`.mc/package-msys2.sh`) that uses `ldd` to discover runtime DLL dependencies from `/ucrt64/bin/`, filtering out Windows system DLLs
- Add macOS packaging script (`.mc/package-macos.sh`) that uses `otool -L` to iteratively resolve Homebrew dylib dependencies, filtering out system libraries
- Both scripts include `gerbv` binary, `libgerbv` shared library, license files (`COPYING`, `COPYING.tinyscheme`, `init.scm`), and all required runtime dependencies
- Add Package + Upload artifact steps to `ci-windows` and `ci-macos` jobs in CI workflow
- Artifact names (`gerbv-windows-msys2`, `gerbv-macos`) match the `gerbv-*` download pattern used by the `release` job
- ZIP filenames follow the `gerbv_{DATE}_{COMMIT}_(OS).zip` convention so the release job's rename sed works without modification

## Test plan

- [x] Verify `ci-windows` job produces a `gerbv-windows-msys2` artifact containing a ZIP with `gerbv.exe`, `libgerbv*.dll`, UCRT64 runtime DLLs, and license files
- [x] Verify `ci-macos` job produces a `gerbv-macos` artifact containing a ZIP with `gerbv`, `libgerbv*.dylib`, Homebrew dylibs, and license files
- [x] Verify the `release` job's rename sed correctly transforms both filenames (e.g. `gerbv_v1.0.0_(macOS).zip`, `gerbv_v1.0.0_(Windows MSYS2 UCRT64).zip`)

Closes #407