### PR TITLE
fix: suppress false warnings for G36/G37-only Gerber files

### DIFF
--- a/src/gerb_image.c
+++ b/src/gerb_image.c
@@ -209,23 +209,34 @@ gerb_verify_error_t
 gerbv_image_verify(gerbv_image_t const* image)
 {
     gerb_verify_error_t error = GERB_IMAGE_OK;
-    int i, n_nets;;
+    int i;
     gerbv_net_t *net;
+    gboolean needs_aperture = FALSE;
+    gboolean in_parea = FALSE;
 
     if (image->netlist == NULL) error |= GERB_IMAGE_MISSING_NETLIST;
     if (image->format == NULL)  error |= GERB_IMAGE_MISSING_FORMAT;
     if (image->info == NULL)    error |= GERB_IMAGE_MISSING_INFO;
 
-    /* Count how many nets we have */
-    n_nets = 0;
+    /* Check if any net actually requires an aperture (i.e., draws or
+     * flashes outside a polygon area fill).  G36/G37 polygon fills
+     * don't need apertures, so files using only polygon fills should
+     * not trigger a missing-apertures warning. */
     if (image->netlist != NULL) {
       for (net = image->netlist->next ; net != NULL; net = net->next) {
-	n_nets++;
+	if (net->interpolation == GERBV_INTERPOLATION_PAREA_START)
+	    in_parea = TRUE;
+	else if (net->interpolation == GERBV_INTERPOLATION_PAREA_END)
+	    in_parea = FALSE;
+	else if (!in_parea &&
+		 (net->aperture_state == GERBV_APERTURE_STATE_ON ||
+		  net->aperture_state == GERBV_APERTURE_STATE_FLASH))
+	    needs_aperture = TRUE;
       }
     }
 
-    /* If we have nets but no apertures are defined, then complain */
-    if( n_nets > 0) {
+    /* If we have nets that need apertures but none are defined, complain */
+    if (needs_aperture) {
       for (i = 0; i < APERTURE_MAX && image->aperture[i] == NULL; i++);
       if (i == APERTURE_MAX) error |= GERB_IMAGE_MISSING_APERTURES;
     }

--- a/src/gerber.c
+++ b/src/gerber.c
@@ -816,6 +816,7 @@ gerber_is_rs274x_p(gerb_file_t *fd, gboolean *returnFoundBinary)
     int i;
     gboolean found_binary = FALSE;
     gboolean found_ADD = FALSE;
+    gboolean found_percent_cmd = FALSE;
     gboolean found_D0 = FALSE;
     gboolean found_D2 = FALSE;
     gboolean found_M0 = FALSE;
@@ -823,9 +824,9 @@ gerber_is_rs274x_p(gerb_file_t *fd, gboolean *returnFoundBinary)
     gboolean found_star = FALSE;
     gboolean found_X = FALSE;
     gboolean found_Y = FALSE;
-   
+
     DPRINTF("%s(%p, %p), fd->fd = %p\n",
-		    __func__, fd, returnFoundBinary, fd->fd); 
+		    __func__, fd, returnFoundBinary, fd->fd);
     buf = (char *) g_malloc(MAXL);
     if (buf == NULL) 
 	GERB_FATAL_ERROR("malloc buf failed while checking for rs274x in %s()",
@@ -849,6 +850,13 @@ gerber_is_rs274x_p(gerb_file_t *fd, gboolean *returnFoundBinary)
 	if (g_strstr_len(buf, len, "%ADD")) {
 	    found_ADD = TRUE;
             DPRINTF("found_ADD\n");
+	}
+	if (g_strstr_len(buf, len, "%FS") ||
+	    g_strstr_len(buf, len, "%MO") ||
+	    g_strstr_len(buf, len, "%LP") ||
+	    g_strstr_len(buf, len, "%AM")) {
+	    found_percent_cmd = TRUE;
+	    DPRINTF("found_percent_cmd\n");
 	}
 	if (g_strstr_len(buf, len, "D00") || g_strstr_len(buf, len, "D0")) {
 	    found_D0 = TRUE;
@@ -890,8 +898,8 @@ gerber_is_rs274x_p(gerb_file_t *fd, gboolean *returnFoundBinary)
     *returnFoundBinary = found_binary;
 
     /* Now form logical expression determining if the file is RS-274X */
-    if ((found_D0 || found_D2 || found_M0 || found_M2) && 
-	found_ADD && found_star && (found_X || found_Y)) 
+    if ((found_D0 || found_D2 || found_M0 || found_M2) &&
+	(found_ADD || found_percent_cmd) && found_star && (found_X || found_Y))
 	return TRUE;
 
     


### PR DESCRIPTION
## Summary

Fixes #409 — valid RS-274X Gerber files using only G36/G37 polygon area fills (no `%ADD` aperture definitions) produce spurious warnings:
- "Most likely found a RS-274D file"
- "Missing apertures/drill sizes...trying to load anyways"

This is a long-standing bug (since 2007), not a regression. Two independent root causes, both fixed here:

**1. RS-274X detection (`gerber.c` — `gerber_is_rs274x_p()`)**

The function only scanned for `%ADD` as an RS-274X indicator. G36/G37-only files have no aperture definitions, so they were misclassified as RS-274D.

Fix: also recognise `%FS`, `%MO`, `%LP`, and `%AM` as RS-274X indicators. Any of these extended commands (present in virtually all RS-274X files) now satisfy the detection check alongside `%ADD`.

**2. Missing apertures check (`gerb_image.c` — `gerbv_image_verify()`)**

The function flagged missing apertures whenever *any* nets existed, but nets inside G36/G37 polygon fills don't reference apertures.

Fix: track whether any net actually requires an aperture — i.e., draws or flashes *outside* a polygon fill region. Only flag `GERB_IMAGE_MISSING_APERTURES` when such nets exist.

## Test plan

- [x] G36/G37-only file from issue #409: no warnings, correct PNG export
- [x] File with undefined aperture usage outside G36/G37: CRITICAL messages still appear correctly
- [x] RS-274X roundtrip export preserves G36/G37 polygon geometry
- [x] Existing test suite: no new failures (94/105 pass; 11 pre-existing golden image mismatches)