### PR TITLE
fix: remove artificial D code limit of 9999

### DIFF
--- a/src/export-drill.c
+++ b/src/export-drill.c
@@ -66,7 +66,7 @@ gerbv_export_drill_file_from_image (const gchar *filename, gerbv_image_t *inputI
 
 	/* the image should already have been cleaned by a duplicate_image call, so we can safely
 	   assume the aperture range is correct */
-	for (int i = APERTURE_MIN; i < APERTURE_MAX; i++) {
+	for (int i = APERTURE_MIN; i < image->aperture_slots; i++) {
 		aperture = image->aperture[i];
 		
 		if (!aperture)

--- a/src/export-isel-drill.c
+++ b/src/export-isel-drill.c
@@ -98,7 +98,7 @@ gerbv_export_isel_drill_file_from_image (const gchar *filename, gerbv_image_t *i
 
 	/* the image should already have been cleaned by a duplicate_image call, so we can safely
 	   assume the aperture range is correct */
-	for (int i=APERTURE_MIN; i<APERTURE_MAX; i++) {
+	for (int i=APERTURE_MIN; i<image->aperture_slots; i++) {
 		currentAperture = image->aperture[i];
 
 		if (!currentAperture)

--- a/src/export-rs274x.c
+++ b/src/export-rs274x.c
@@ -118,7 +118,7 @@ export_rs274x_write_apertures (FILE *fd, gerbv_image_t *image) {
 	
 	/* the image should already have been cleaned by a duplicate_image call, so we can safely
 	   assume the aperture range is correct */
-	for (i=APERTURE_MIN; i<APERTURE_MAX; i++) {
+	for (i=APERTURE_MIN; i<image->aperture_slots; i++) {
 		gboolean writeAperture=TRUE;
 		
 		currentAperture = image->aperture[i];

--- a/src/gerb_image.c
+++ b/src/gerb_image.c
@@ -52,8 +52,16 @@ gerbv_create_image(gerbv_image_t *image, const gchar *type)
 	return NULL;
     }
 
+    /* Malloc space for dynamic aperture array */
+    if (NULL == (image->aperture = g_new0(gerbv_aperture_t *, APERTURE_INITIAL_SLOTS))) {
+	g_free(image);
+	return NULL;
+    }
+    image->aperture_slots = APERTURE_INITIAL_SLOTS;
+
     /* Malloc space for image->netlist */
     if (NULL == (image->netlist = g_new0(gerbv_net_t, 1))) {
+	g_free(image->aperture);
 	g_free(image);
 	return NULL;
     }
@@ -61,6 +69,7 @@ gerbv_create_image(gerbv_image_t *image, const gchar *type)
     /* Malloc space for image->info */
     if (NULL == (image->info = g_new0(gerbv_image_info_t, 1))) {
 	g_free(image->netlist);
+	g_free(image->aperture);
 	g_free(image);
 	return NULL;
     }
@@ -102,6 +111,31 @@ gerbv_create_image(gerbv_image_t *image, const gchar *type)
 }
 
 
+gboolean
+gerbv_image_ensure_aperture_slot(gerbv_image_t *image, int index)
+{
+    if (index < 0)
+	return FALSE;
+    if (index < image->aperture_slots)
+	return TRUE;
+    if (index >= APERTURE_SLOTS_MAX)
+	return FALSE;
+
+    int new_slots = image->aperture_slots;
+    while (new_slots <= index)
+	new_slots *= 2;
+    if (new_slots > APERTURE_SLOTS_MAX)
+	new_slots = APERTURE_SLOTS_MAX;
+
+    image->aperture = g_realloc(image->aperture,
+		new_slots * sizeof(gerbv_aperture_t *));
+    memset(image->aperture + image->aperture_slots, 0,
+		(new_slots - image->aperture_slots) * sizeof(gerbv_aperture_t *));
+    image->aperture_slots = new_slots;
+    return TRUE;
+}
+
+
 void
 gerbv_destroy_image(gerbv_image_t *image)
 {
@@ -117,7 +151,7 @@ gerbv_destroy_image(gerbv_image_t *image)
     /*
      * Free apertures
      */
-    for (i = 0; i < APERTURE_MAX; i++) 
+    for (i = 0; i < image->aperture_slots; i++)
 	if (image->aperture[i] != NULL) {
 	    for (sam = image->aperture[i]->simplified; sam != NULL; ){
 	      sam2 = sam->next;
@@ -128,6 +162,7 @@ gerbv_destroy_image(gerbv_image_t *image)
 	    g_free(image->aperture[i]);
 	    image->aperture[i] = NULL;
 	}
+    g_free(image->aperture);
 
     /*
      * Free aperture macro
@@ -237,8 +272,8 @@ gerbv_image_verify(gerbv_image_t const* image)
 
     /* If we have nets that need apertures but none are defined, complain */
     if (needs_aperture) {
-      for (i = 0; i < APERTURE_MAX && image->aperture[i] == NULL; i++);
-      if (i == APERTURE_MAX) error |= GERB_IMAGE_MISSING_APERTURES;
+      for (i = 0; i < image->aperture_slots && image->aperture[i] == NULL; i++);
+      if (i == image->aperture_slots) error |= GERB_IMAGE_MISSING_APERTURES;
     }
 
     return error;
@@ -273,7 +308,7 @@ gerbv_image_dump(gerbv_image_t const* image)
     /* Apertures */
     printf(_("Apertures:\n"));
     aperture = image->aperture;
-    for (i = 0; i < APERTURE_MAX; i++) {
+    for (i = 0; i < image->aperture_slots; i++) {
 	if (aperture[i]) {
 	    printf(_(" Aperture no:%d is an "), i);
 	    switch(aperture[i]->type) {
@@ -437,7 +472,7 @@ gerbv_image_copy_all_nets (gerbv_image_t *sourceImage,
 	if (trans) {
 		/* Find last used aperture to add transformed apertures if
 		 * needed */
-		for (aper_last_id = APERTURE_MAX - 1; aper_last_id > 0;
+		for (aper_last_id = destImage->aperture_slots - 1; aper_last_id > 0;
 						aper_last_id--) {
 			if (destImage->aperture[aper_last_id] != NULL)
 				break;
@@ -563,6 +598,7 @@ gerbv_image_copy_all_nets (gerbv_image_t *sourceImage,
 				aper->parameter[0] *= trans->scaleX;
 
 				trans_apers[newNet->aperture] = ++aper_last_id;
+				gerbv_image_ensure_aperture_slot(destImage, aper_last_id);
 				destImage->aperture[aper_last_id] = aper;
 				newNet->aperture = aper_last_id;
 			} else {
@@ -599,6 +635,7 @@ gerbv_image_copy_all_nets (gerbv_image_t *sourceImage,
 			}
 
 			trans_apers[newNet->aperture] = ++aper_last_id;
+			gerbv_image_ensure_aperture_slot(destImage, aper_last_id);
 			destImage->aperture[aper_last_id] = aper;
 			newNet->aperture = aper_last_id;
 
@@ -809,6 +846,7 @@ selection_add_item (&screen.selectionInfo, &sItem);
 			}
 
 			trans_apers[newNet->aperture] = ++aper_last_id;
+			gerbv_image_ensure_aperture_slot(destImage, aper_last_id);
 			destImage->aperture[aper_last_id] = aper;
 			newNet->aperture = aper_last_id;
 
@@ -885,7 +923,7 @@ gerbv_image_find_existing_aperture_match (gerbv_aperture_t *checkAperture, gerbv
     int i,j;
     gboolean isMatch;
     
-    for (i = 0; i < APERTURE_MAX; i++) {
+    for (i = 0; i < imageToSearch->aperture_slots; i++) {
 	if (imageToSearch->aperture[i] != NULL) {
 	  if ((imageToSearch->aperture[i]->type == checkAperture->type) &&
 	      (imageToSearch->aperture[i]->simplified == NULL) &&
@@ -908,7 +946,7 @@ int
 gerbv_image_find_unused_aperture_number (int startIndex, gerbv_image_t *image){
     int i;
     
-    for (i = startIndex; i < APERTURE_MAX; i++) {
+    for (i = startIndex; i < image->aperture_slots; i++) {
 	if (image->aperture[i] == NULL) {
 	  return i;
 	}
@@ -934,7 +972,7 @@ gerbv_image_duplicate_image (gerbv_image_t *sourceImage, gerbv_user_transformati
     
     /* copy apertures over, compressing all the numbers down for a cleaner output, and
        moving and apertures less than 10 up to the correct range */
-    for (i = 0; i < APERTURE_MAX; i++) {
+    for (i = 0; i < sourceImage->aperture_slots; i++) {
 	if (sourceImage->aperture[i] != NULL) {
 	  gerbv_aperture_t *newAperture = gerbv_image_duplicate_aperture (sourceImage->aperture[i]);
 
@@ -943,6 +981,7 @@ gerbv_image_duplicate_image (gerbv_image_t *sourceImage, gerbv_user_transformati
 	  gerb_translation_entry_t translationEntry={i,lastUsedApertureNumber};
 	  g_array_append_val (apertureNumberTable,translationEntry);
 
+	  gerbv_image_ensure_aperture_slot(newImage, lastUsedApertureNumber);
 	  newImage->aperture[lastUsedApertureNumber] = newAperture;
 	}
     }
@@ -961,10 +1000,10 @@ gerbv_image_copy_image (gerbv_image_t *sourceImage, gerbv_user_transformation_t 
     GArray *apertureNumberTable = g_array_new(FALSE,FALSE,sizeof(gerb_translation_entry_t));
     
     /* copy apertures over */
-    for (i = 0; i < APERTURE_MAX; i++) {
+    for (i = 0; i < sourceImage->aperture_slots; i++) {
 	if (sourceImage->aperture[i] != NULL) {
 	  gint existingAperture = gerbv_image_find_existing_aperture_match (sourceImage->aperture[i], destinationImage);
-	  
+
 	  /* if we already have an existing aperture in the destination image that matches what
 	     we want, just use it instead */
 	  if (existingAperture > 0) {
@@ -974,12 +1013,13 @@ gerbv_image_copy_image (gerbv_image_t *sourceImage, gerbv_user_transformation_t 
 	  /* else, create a new aperture and put it in the destination image */
 	  else {
 	  	gerbv_aperture_t *newAperture = gerbv_image_duplicate_aperture (sourceImage->aperture[i]);
-	  
+
 	  	lastUsedApertureNumber = gerbv_image_find_unused_aperture_number (lastUsedApertureNumber + 1, destinationImage);
 	  	/* store the aperture numbers (new and old) in the translation table */
 	  	gerb_translation_entry_t translationEntry={i,lastUsedApertureNumber};
 	  	g_array_append_val (apertureNumberTable,translationEntry);
 
+	  	gerbv_image_ensure_aperture_slot(destinationImage, lastUsedApertureNumber);
 	  	destinationImage->aperture[lastUsedApertureNumber] = newAperture;
 	  }
 	}
@@ -1105,9 +1145,9 @@ gerb_image_return_aperture_index (gerbv_image_t *image, gdouble lineWidth, int *
 	for (currentNet = image->netlist; currentNet->next; currentNet = currentNet->next){}
 	
 	/* try to find an existing aperture that matches the requested width and type */
-	for (i = 0; i < APERTURE_MAX; i++) {
+	for (i = 0; i < image->aperture_slots; i++) {
 		if (image->aperture[i] != NULL) {
-			if ((image->aperture[i]->type == GERBV_APTYPE_CIRCLE) && 
+			if ((image->aperture[i]->type == GERBV_APTYPE_CIRCLE) &&
 				(fabs (image->aperture[i]->parameter[0] - lineWidth) < 0.001)){
 				aperture = image->aperture[i];
 				*apertureIndex = i;

--- a/src/gerber.c
+++ b/src/gerber.c
@@ -111,7 +111,7 @@ gerber_create_new_aperture (gerbv_image_t *image, int *indexNumber,
 	int i;
 	
 	/* search for an available aperture spot */
-	for (i = 0; i <= APERTURE_MAX; i++) {
+	for (i = 0; i < image->aperture_slots; i++) {
 		if (image->aperture[i] == NULL) {
 			image->aperture[i] = g_new0 (gerbv_aperture_t, 1);
 			image->aperture[i]->type = apertureType;
@@ -1073,10 +1073,10 @@ parse_G_code(gerb_file_t *fd, gerb_state_t *state,
 	/* XXX Maybe uneccesary??? */
 	if (gerb_fgetc(fd) == 'D') {
 	    int a = gerb_fgetint(fd, NULL);
-	    if ((a >= 0) && (a <= APERTURE_MAX)) {
+	    if ((a >= 0) && gerbv_image_ensure_aperture_slot(image, a)) {
 		state->curr_aperture = a;
-	    } else { 
-		gerbv_stats_printf(error_list, GERBV_MESSAGE_ERROR, -1, 
+	    } else {
+		gerbv_stats_printf(error_list, GERBV_MESSAGE_ERROR, -1,
 			_("Found aperture D%02d out of bounds while parsing "
 			    "G code at line %ld in file \"%s\""),
 			a, *line_num_p, fd->filename);
@@ -1174,9 +1174,9 @@ parse_D_code(gerb_file_t *fd, gerb_state_t *state,
 	stats->D3++;
 	break;
     default: /* Aperture in use */
-	if ((a >= 0) && (a <= APERTURE_MAX)) {
+	if ((a >= 0) && gerbv_image_ensure_aperture_slot(image, a)) {
 	    state->curr_aperture = a;
-	    
+
 	} else {
 	    gerbv_stats_printf(error_list, GERBV_MESSAGE_ERROR, -1,
 		    _("Found out of bounds aperture D%02d "
@@ -1187,7 +1187,7 @@ parse_D_code(gerb_file_t *fd, gerb_state_t *state,
 	state->changed = 0;
 	break;
     }
-    
+
     return;
 } /* parse_D_code */
 
@@ -1672,7 +1672,7 @@ parse_rs274x(gint levelOfRecursion, gerb_file_t *fd, gerbv_image_t *image,
 	if (ano == -1) {
 		/* error with line parse, so just quietly ignore */
 	}
-	else if ((ano >= 0) && (ano <= APERTURE_MAX)) {
+	else if ((ano >= 0) && gerbv_image_ensure_aperture_slot(image, ano)) {
 	    a->unit = state->state->unit;
 	    image->aperture[ano] = a;
 	    DPRINTF("     In %s(), adding new aperture to aperture list ...\n",

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -93,7 +93,8 @@ extern "C" {
 #endif
 
 #define APERTURE_MIN 10
-#define APERTURE_MAX 9999
+#define APERTURE_INITIAL_SLOTS 10001
+#define APERTURE_SLOTS_MAX 10000001
 
 /*
  * Maximum number of aperture parameters is set by the outline aperture macro.
@@ -720,7 +721,8 @@ typedef struct gerbv_image_info {
 /*!  The structure used to hold a layer (RS274X, drill, or pick-and-place data) */
 typedef struct {
   gerbv_layertype_t layertype; /*!< the type of layer (RS274X, drill, or pick-and-place) */
-  gerbv_aperture_t *aperture[APERTURE_MAX]; /*!< an array with all apertures used */
+  gerbv_aperture_t **aperture; /*!< a dynamically-allocated array of aperture pointers */
+  int aperture_slots; /*!< number of allocated slots in the aperture array */
   gerbv_layer_t *layers; /*!< an array of all RS274X layers used (only used in RS274X types) */
   gerbv_netstate_t *states; /*!< an array of all RS274X states used (only used in RS274X types) */
   gerbv_amacro_t *amacro; /*!< an array of all macros used (only used in RS274X types) */
@@ -791,6 +793,9 @@ gerbv_image_t *gerbv_create_image(gerbv_image_t *image, /*!< the old image to fr
 //! Free an image structure
 void gerbv_destroy_image(gerbv_image_t *image /*!< the image to free */
 );
+
+//! Ensure the aperture array has room for the given index, growing if needed
+gboolean gerbv_image_ensure_aperture_slot(gerbv_image_t *image, int index);
 
 //! Copy an image into an existing image, effectively merging the two together
 void

--- a/test/test_d10000.gbr
+++ b/test/test_d10000.gbr
@@ -1,0 +1,7 @@
+G04 Test file for D10000 - reporter's test case*
+%FSLAX36Y36*%
+%MOIN*%
+%ADD10000C,1.000000*%
+D10000*
+X0Y0D03*
+M02*

--- a/test/test_d100000.gbr
+++ b/test/test_d100000.gbr
@@ -1,0 +1,7 @@
+G04 Test file for D100000 - large D code triggers array growth*
+%FSLAX36Y36*%
+%MOIN*%
+%ADD100000C,0.500000*%
+D100000*
+X0Y0D03*
+M02*

--- a/test/test_d9999.gbr
+++ b/test/test_d9999.gbr
@@ -1,0 +1,7 @@
+G04 Test file for D9999 - off-by-one fix verification*
+%FSLAX36Y36*%
+%MOIN*%
+%ADD9999C,0.250000*%
+D9999*
+X0Y0D03*
+M02*


### PR DESCRIPTION
## Summary

Fixes #411 — D codes > 9999 produce "Aperture number out of bounds" errors despite the Gerber spec (Rev 2024.05, §4.3.1) allowing aperture numbers from 10 up to 2,147,483,647 (max int32).

**Root cause:** Apertures are stored in a fixed-size array `gerbv_aperture_t *aperture[APERTURE_MAX]` where `APERTURE_MAX=9999`, directly indexed by D code number.

**Fix:** Replace the fixed-size embedded array with a dynamically-allocated, growable pointer array:
- Initial allocation: 10,001 slots (indices 0–10000, covers existing range + the reporter's D10000 case)
- Growth: doubles when exceeded, capped at 10,000,001 slots (~80 MB) to prevent OOM from malformed files
- Preserves `image->aperture[i]` access pattern throughout the codebase (minimal diff)

**Also fixes a pre-existing off-by-one bug:** The old array had 9999 elements (indices 0–9998), but validation allowed `ano <= 9999`, meaning D9999 caused an out-of-bounds write.

## Changes

| File | Change |
|------|--------|
| `gerbv.h` | Replace `APERTURE_MAX` with `APERTURE_INITIAL_SLOTS`/`APERTURE_SLOTS_MAX`; change fixed array to `gerbv_aperture_t **aperture` + `int aperture_slots` |
| `gerb_image.c` | Allocate dynamic array in `gerbv_create_image()`; add `gerbv_image_ensure_aperture_slot()` for on-demand growth; update all loop bounds and free in `gerbv_destroy_image()` |
| `gerber.c` | Parser validation uses `ensure_aperture_slot()` instead of fixed bound checks (AD, G54, D code selection); fix off-by-one in `gerber_create_new_aperture()` |
| `export-rs274x.c` | Loop bound `APERTURE_MAX` → `image->aperture_slots` |
| `export-drill.c` | Loop bound `APERTURE_MAX` → `image->aperture_slots` |
| `export-isel-drill.c` | Loop bound `APERTURE_MAX` → `image->aperture_slots` |

## Test plan

- [x] Reporter's test case: file with `%ADD10000C,1.000000*%` and `D10000*` loads without errors
- [x] D9999 no longer causes out-of-bounds access (off-by-one fix)
- [x] Large D code (D100000) triggers array growth and works correctly
- [x] D codes > 10,000,000 produce error instead of OOM
- [x] Clean build with zero warnings
- [x] Existing test suite: 94/105 pass (11 failures are pre-existing image comparison mismatches, unrelated to this change)
- [x] Export round-trip: load file with D10000, export RS-274X, verify aperture data preserved

## Other artificial limits found during investigation

These are **not** addressed in this PR but are worth noting for spec compliance:

| Constant | File | Value | Note |
|----------|------|-------|------|
| `TOOL_MAX` | `drill.h:41` | 9999 | No explicit limit in Excellon spec |
| `MAX_TOOL_NUMBER` | `tooltable.c:38` | 99 | Inconsistent with `TOOL_MAX` |
| `MAXL` | `gerber.c:51` | 200 chars | Gerber spec has no line length limit |
| `APERTURE_PARAMETERS_MAX` | `gerbv.h:104` | 10006 | Based on 5000-point outline assumption |
| `MATH_OP_STACK_SIZE` | `amacro.c:104` | 2 | May limit complex macro expressions |