### PR TITLE
Build libgerbv in shared mode when configuring for install.

### DIFF
--- a/cmake/preset/linux-gnu-gcc.json
+++ b/cmake/preset/linux-gnu-gcc.json
@@ -11,7 +11,8 @@
             "name": "linux-gnu-gcc-install",
             "inherits": "linux-gnu-gcc",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "/opt/gerbv.github/"
+                "CMAKE_INSTALL_PREFIX": "/opt/gerbv.github/",
+                "BUILD_SHARED_LIBS": "ON"
             }
         }
     ],


### PR DESCRIPTION
The SHARED flag was removed, but it was said that it still built in shared by default. Now I have updated so that when running the configuration preset linux-gnu-gcc-install the shared libgerbv.so will be built. That is by setting the flag "BUILD_SHARED_LIBS" to "ON".

The configuration preset linux-gnu-gcc-install is used when compiling files to be used in packaging for release. So by default it will continue to build libgerbv.a all the other times.

See more in #416 

Closes #416 