### PR TITLE
fix: GDK rounding for all shape primitives (#167)

### DIFF
--- a/src/draw-gdk.c
+++ b/src/draw-gdk.c
@@ -95,8 +95,8 @@ gerbv_gdk_draw_prim1(GdkPixmap *pixmap, GdkGC *gc, gerbv_simplified_amacro_t *s,
     const gint full_circle = 23360;
     GdkGC *local_gc = gdk_gc_new(pixmap);
     gint dia    = round(fabs(s->parameter[diameter_idx] * scale));
-    gint real_x = x - dia / 2;
-    gint real_y = y - dia / 2;
+    gint real_x = round(x - dia / 2.0);
+    gint real_y = round(y - dia / 2.0);
     GdkPoint center;
     GdkColor color;
 
@@ -286,7 +286,7 @@ gerbv_gdk_draw_prim6(GdkPixmap *pixmap, GdkGC *gc, gerbv_simplified_amacro_t *s,
 	const gint full_circle = 23360;
 	gint dia = (real_dia - real_dia_diff * circle) * scale;
 	if (dia >= 0){
-		gdk_draw_arc(pixmap, local_gc, 0, x - dia / 2, y - dia / 2, 
+		gdk_draw_arc(pixmap, local_gc, 0, round(x - dia / 2.0), round(y - dia / 2.0),
 				dia, dia, 0, full_circle);
 	}
     }
@@ -356,7 +356,7 @@ gerbv_gdk_draw_prim7(GdkPixmap *pixmap, GdkGC *gc, gerbv_simplified_amacro_t *s,
      * Non filled circle 
      */
     diameter = (s->parameter[inside_dia_idx] + ci_thickness) * scale;
-    gdk_draw_arc(pixmap, local_gc, 0, x - diameter / 2, y - diameter / 2, 
+    gdk_draw_arc(pixmap, local_gc, 0, round(x - diameter / 2.0), round(y - diameter / 2.0),
 		 diameter, diameter, 0, full_circle);
 
     /*
@@ -612,9 +612,9 @@ gerbv_gdk_draw_circle(GdkPixmap *pixmap, GdkGC *gc,
 		  gint filled, gint x, gint y, gint dia)
 {
     static const gint full_circle = 23360;
-    gint real_x = x - dia / 2;
-    gint real_y = y - dia / 2;
-    
+    gint real_x = round(x - dia / 2.0);
+    gint real_y = round(y - dia / 2.0);
+
     gdk_draw_arc(pixmap, gc, filled, real_x, real_y, dia, dia, 0, full_circle);
     
     return;
@@ -632,12 +632,12 @@ gerbv_gdk_draw_rectangle(GdkPixmap *pixmap, GdkGC *gc,
 	int i;
 	GdkPoint points[4];
 
-	points[0].x = -(x_side >> 1);
-	points[0].y = -(y_side >> 1);
-	points[1].x = x_side >> 1;
+	points[0].x = round(-(x_side / 2.0));
+	points[0].y = round(-(y_side / 2.0));
+	points[1].x = round(x_side / 2.0);
 	points[1].y = points[0].y;
 	points[2].x = points[1].x;
-	points[2].y = y_side >> 1;
+	points[2].y = round(y_side / 2.0);
 	points[3].x = points[0].x;
 	points[3].y = points[2].y;
 
@@ -671,18 +671,18 @@ gerbv_gdk_draw_oval(GdkPixmap *pixmap, GdkGC *gc,
 		/* Draw in x axis */
 		width = y_axis;
 
-		points[0].x = -(x_axis >> 1) + (y_axis >> 1);
+		points[0].x = round(-(x_axis / 2.0) + (y_axis / 2.0));
 		points[0].y = 0;
-		points[1].x =  (x_axis >> 1) - (y_axis >> 1);
+		points[1].x = round( (x_axis / 2.0) - (y_axis / 2.0));
 		points[1].y = 0;
 	} else {
 		/* Draw in y axis */
 		width = x_axis;
 
 		points[0].x = 0;
-		points[0].y = -(y_axis >> 1) + (x_axis >> 1);
+		points[0].y = round(-(y_axis / 2.0) + (x_axis / 2.0));
 		points[1].x = 0;
-		points[1].y =  (y_axis >> 1) - (x_axis >> 1);
+		points[1].y = round( (y_axis / 2.0) - (x_axis / 2.0));
 	}
 
 	points[0] = rotate_point(points[0], angle_deg);


### PR DESCRIPTION
## Summary

Extends the fix from PR #173 (which corrected arc bounding-box rounding) to all remaining shape primitives in the GDK renderer:

- **`gerbv_gdk_draw_circle`** — `x - dia / 2` → `round(x - dia / 2.0)`
- **`gerbv_gdk_draw_prim1`** (macro circle) — same pattern
- **`gerbv_gdk_draw_prim6`** (moiré) — inline `gdk_draw_arc` call
- **`gerbv_gdk_draw_prim7`** (thermal) — inline `gdk_draw_arc` call
- **`gerbv_gdk_draw_rectangle`** — `>> 1` → `round(... / 2.0)`
- **`gerbv_gdk_draw_oval`** — `>> 1` → `round(... / 2.0)`

Integer division (`/ 2` or `>> 1`) truncates toward zero, causing the bounding-box top-left corner to be off by one pixel for odd-valued dimensions. This makes concentric apertures (e.g. a pad with a drilled hole) appear misaligned at low zoom levels when using the GDK fast renderer.

Using `round(... / 2.0)` (which maps to `ceil()` via the local macro) matches the fix already applied to `gerbv_gdk_draw_arc` in #173.

Fixes #167

## Test plan

- [x] `cmake --build` completes without warnings
- [x] `ctest` regression suite: same 11 pre-existing pixel-mismatch failures on both `develop` and this branch (no new failures)
- [ ] Visual: load a Gerber with THT pads at low zoom in GDK mode, confirm pad/hole concentricity