### PR TITLE
Fix bug in when BuildOptions.cmake checks if variables are defined or…

### DIFF
--- a/BuildOptions.cmake
+++ b/BuildOptions.cmake
@@ -2,12 +2,12 @@
 option(DEBUG_PRINTOUT "Print out debug messages as gerbv process files" FALSE)
 
 # Default border coefficient for export
-if(NOT DEFINED ${GERBV_DEFAULT_BORDER_COEFF})
+if(NOT DEFINED GERBV_DEFAULT_BORDER_COEFF)
     set(GERBV_DEFAULT_BORDER_COEFF 0.05)
 endif()
 
 # Default unit to display in statusbar
 # Possible values are "GERBV_MILS", "GERBV_MMS" or "GERBV_INS"
-if(NOT DEFINED ${GERBV_DEFAULT_UNIT})
+if(NOT DEFINED GERBV_DEFAULT_UNIT)
     set(GERBV_DEFAULT_UNIT "GERBV_MILS")
 endif()


### PR DESCRIPTION
… not

Previously CMake thought the varaibles was always 'not defined' and wrote over the value given on the command line as -D parameter.