### PR TITLE
Moved install() command for init.scm to tinyscheme CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,8 +98,6 @@ if(APPLE)
 endif()
 
 install(TARGETS gerbv-app)
-install(FILES ${CMAKE_SOURCE_DIR}/thirdparty/tinyscheme/init.scm
-        DESTINATION ${BACKEND_DIR})
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "\$\{prefix\}")

--- a/thirdparty/dxflib/CMakeLists.txt
+++ b/thirdparty/dxflib/CMakeLists.txt
@@ -1,7 +1,11 @@
 
 # Bundled dxflib (GPL-2+, RibbonSoft/QCAD)
 add_library(dxflib_bundled OBJECT)
+
 target_sources(dxflib_bundled PRIVATE dl_dxf.cpp dl_writer_ascii.cpp)
+
 set_target_properties(dxflib_bundled PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(dxflib_bundled PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
 target_link_libraries(dxflib_bundled PRIVATE gettext_support)

--- a/thirdparty/tinyscheme/CMakeLists.txt
+++ b/thirdparty/tinyscheme/CMakeLists.txt
@@ -3,11 +3,16 @@ add_library(tinyscheme STATIC)
 
 ## Bundled TinyScheme 1.35 (BSD 3-Clause, Dimitrios Souflis)
 target_sources(tinyscheme PRIVATE scheme.c dynload.c)
+
 set_target_properties(tinyscheme PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(tinyscheme PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-# target_include_directories(tinyscheme PRIVATE
-#    ${CMAKE_SOURCE_DIR}/src)
+
 target_link_libraries(tinyscheme PRIVATE config gettext_support)
+
 if(Intl_FOUND)
     target_link_libraries(tinyscheme PRIVATE Intl::Intl)
 endif()
+
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/init.scm
+        DESTINATION ${BACKEND_DIR})


### PR DESCRIPTION
A tiny fix to make sure all tinyscheme things (both files and configurations) is in the thirdparty/tinyscheme.

Took the opportunity to make sure some CMakeLists.txt is more readable by adding newlines.