### PR TITLE
Update linux packaging

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,4 +1,13 @@
 configure_file(gerbv.1.in ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1 @ONLY)
 
 cmake_path(SET CMAKE_INSTALL_MANDIR NORMALIZE ${CMAKE_INSTALL_MANDIR}/man1)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1 TYPE MAN)
+
+# Debian and Redhat installs compressed man pages, macos and the rest does not.
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    file(ARCHIVE_CREATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1.gz
+                        PATHS ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1
+                        COMPRESSION GZip)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1.gz TYPE MAN)
+else()
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gerbv.1 TYPE MAN)
+endif()


### PR DESCRIPTION
Updates what goes into the Linux packages `deb` and `rpm`

The only thing left in this PR is now:
1.  The man pages in the Linux packages should now be compressed, other packages does not
