### PR TITLE
BUILD.md is added and README.md is updated

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,226 @@
+# How to build Gerbv
+
+Gerbv now uses CMake with *presets*, uses the *Ninja Multi-Config* generator and also *toolchains*.
+*Install* and *CPack* is also used extensively to be able to create easy to use multiplatform support.
+
+It gives slightly different build operations, but should be much easier. Despite the abundance of
+CMake information on the Net, I write this down. Also what presets there are in Gerbv and how
+they work together.
+
+A short introduction about some of the philosophy of how the presets, toolchain etc comes together in
+Gerbv is from [Harald Achitz presentation at SwedenCPP](https://www.youtube.com/watch?v=3VJPfwn1f2o)
+(15 min worth of your time).
+
+All CMake configuration (except the usual `CMakePresets.json` and `CMakeLists.txt`) are stored in the `cmake` directory.
+* `cmake/preset` for the presets
+* `cmake/toolchains` for the toolchains
+* `cmake/Packing.cmake` for the `CPack` configuration (packages deb/rpm/etc)
+
+The `Packing.cmake` is a bit messy at the time of writing this. A split of this should be on the agenda.
+
+There is also the the possibility to use a local `CMakeUserPresets.json` you can use for your own preferences
+if you need one. Please note that that file is in the `.gitignore` and will thus never be merged into the
+repository. This is per CMake recommendations.
+
+## Quick summary
+
+Building locally on a Linux/GCC based machine to test/run locally:
+```
+rm -rf build
+cmake --preset linux-gnu-gcc
+cmake --build --preset linux-gnu-gcc
+```
+Binary is now in `build/src/Debug/gerbv`
+
+Building a Debian package to install using `dpkg -i`
+```
+rm -rf build
+cmake --preset linux-gnu-gcc-install
+cmake --build --preset linux-gnu-gcc-release
+cpack --preset deb-opt
+sudo dpkg -i _packages/gerbv<Something>.deb
+```
+
+## Presets and toolchains
+
+Presets basically describes configuration, build and test recipes. Instead of entering long lines of `-D` parameters,
+build directories, source directories and whats not, everything is prepared for the most common scenarios.
+The presets file also contains references to a toolchain for the particular preset.
+
+Toolchains are used to describe the quirks of your compiler and platform. Extra flags, configurations etc.
+
+### Presets
+
+#### General usage of the presets
+
+To see available presets, you can list them with `--list-presets`
+
+For configure presets
+```
+cmake --list-presets
+```
+For build presets
+```
+cmake --build --list-presets
+```
+For test presets
+```
+ctest --list-presets
+```
+For package presets
+```
+cpack --list-presets
+```
+
+**Note** In many shells you can use tab completion to get the full name of a parameter.
+
+#### Configuration presets in Gerbv
+
+Doing `cmake --list-presets` in Gerbv gives (at the time of writing)
+```
+$ cmake --list-presets
+Available configure presets:
+
+  "linux-gnu-gcc"
+  "linux-gnu-gcc-install"
+  "macos-clang"
+  "mingw-w64-gcc"
+  "msys2-ucrt64-gcc"
+```
+Here are the different platforms listed. The difference between `linux-gnu-gcc` and `linux-gnu-gcc-install` is
+that CMake requires you to set the installation directory already in the configuration stage. So `linux-gnu-gcc-install`
+sets the install directory to `/opt/gerbv.github/`, since that is a requirement for thirdparty packages in Debian.
+
+**Note** We don't say anything about `Debug` or `Release` build here, since we are using the `Ninja Multi-Config` generator.
+
+After configuration you should have a `build` directory, and in that there should be a `compile_commands.json` that
+describes all flags that will be used when compiling. Also in there should be the generated `config/config.h`, which is
+the generated configuration file used throughout the project. Those two files can be used to check that all the
+compilation flags and defines have been set properly.
+
+In `build/src` you have three directories
+* `build/src/Debug/`
+* `build/src/Release/`
+* `build/src/RelWithDebInfo/`
+
+They are empty, but they will be used in the following build stage where we will tell what kind of build we want.
+
+#### Build presets in Gerbv
+
+Doing `cmake --build --list-presets` after the previous configuration stage gives (at the time of writing)
+```
+$ cmake --build --list-presets
+Available build presets:
+
+  "linux-gnu-gcc"
+  "linux-gnu-gcc-release"
+  "macos-clang"
+  "macos-clang-release"
+  "mingw-w64-gcc"
+  "mingw-w64-gcc-release"
+  "msys2-ucrt64-gcc"
+  "msys2-ucrt64-gcc-release"
+```
+Here we define if we should do a `Debug` or a `Release` build. Default is, as you probably understand, `Debug`.
+The build `RelWithDebInfo` is not used by us at the moment.
+
+#### Test presets in Gerbv
+
+The test implemented in Gerbv is a pixel-by-pixel comparison of generated PNG with Golden versions to
+see if anything changed. Basically only used in the pipeline.
+
+```
+$ ctest --list-presets
+Available test presets:
+
+  "linux-gnu-gcc"
+  "macos-clang"
+  "msys2-ucrt64-gcc"
+```
+
+#### Install preset
+
+For install there is no preset, it is not even defined in CMake.
+Simply do
+```
+cmake --install build
+```
+and it will install the `Release` version onto your machine. You probably need to prepend `sudo` if you are
+going to install Gerbv globally on your machine.
+
+#### Packaging presets
+
+Doing `cpack --list-presets` after building a release above gives (at the time of writing)
+
+```
+$ cpack --list-presets
+Available package presets:
+
+  "deb"
+  "deb-opt"
+  "rpm"
+  "rpm-opt"
+```
+
+The simple difference between the `-opt` and non `-opt` is that the `-opt` will build a package that is
+installed in `/opt/gerbv.github`. The package will be built in `_packages`.
+
+### Toolchains
+
+Toolchain files are a way to separate platform dependencies. It is very common in the embedded world where
+you for instance do a lot of cross compiling. We do some cross compiling as well, since one of the Windows
+platforms is cross compiled on a Linux machine using Fedora.
+
+It is a way to keep the compiler versions, special flags etc out of your `CMakeLists.txt`. The `CMakeLists.txt`
+should only describe how you build your source code, not special hacks to keep your compiler happy.
+
+### Build options
+
+There are some parameters that can be changed during **configuration** of the build. They are defined in the
+`BuildOptions.cmake` file and they are currently:
+* `DEBUG_PRINTOUT` Print out debug messages as gerbv processes files (default FALSE)
+* `GERBV_DEFAULT_BORDER_COEFF` Default border coefficient for export (default 0.05)
+* `GERBV_DEFAULT_UNIT` Default unit to display in statusbar Possible values are `GERBV_MILS`, `GERBV_MMS` or `GERBV_INS` (default `GERBV_MILS`)
+
+#### DEBUG_PRINTOUT  Print out debug messages as gerbv process files
+
+Prints out every operation that happens in the code, see `DPRINT`.
+Enable by `-DDEBUG_PRINTOUT=TRUE`. Currently not working properly. Update `DEBUG` in `config/config.h.in`
+to get debug printouts and rerun configuration. Developer specific flag.
+
+#### GERBV_DEFAULT_BORDER_COEFF Default border coefficient for export
+
+Set by `-DGERBV_DEFAULT_BORDER_COEFF=<value>` where <value> is a floating point value.
+
+#### GERBV_DEFAULT_UNIT Default unit to display in statusbar
+
+To change to millimeters for example, add `-DGERBV_DEFAULT_UNIT=GERBV_MILS` to CMake configuration.
+Possible values are `GERBV_MILS`, `GERBV_MMS` or `GERBV_INS`
+
+## IDEs
+
+Many modern IDEs have now support for CMake and CMakePresets that simplifies life.
+
+### VSCode
+
+Except the usual C/C++ extensions there is a *CMake Tools* extension. So I personally have the following C/C++ extensions,
+all from Microsoft.
+* **C/C++**
+* **C/C++ DevTools**
+* **C/C++ Extension Pack**
+* **C/C++ Themes**
+
+The CMake tool is simply called **CMake Tools**, which I also have installed.
+
+On the menu to the left you get a triangle (CMake symbol) with a small wrench. From there you can configure your CMake setup.
+
+In the `.vscode/settings.json` I recommend to set the following
+```
+{
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "C_Cpp.dimInactiveRegions": true,
+    "cmake.languageSupport.dotnetPath": "/bin/dotnet",
+}
+```
+Not sure about the `dotnetPath`, but the first line is the interesting part. But VSCode probably automatically discovers
+that this is a CMake project and configures itself accordingly.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,17 @@ Gerbv was originally developed as part of the
 
 Official releases are published on [GitHub Releases][download-official].
 Moreover, CI generated binaries are published on [gerbv.github.io][download-ci].
+
 Be aware however that they are not manually verified!
+
+### Current status on packages:
+
+The [download-ci] page is not updated properly at the moment, but latest build
+can be downloaded straight from the pipeline at [download-actions].
 
 [download-official]: https://github.com/gerbv/gerbv/releases
 [download-ci]: https://gerbv.github.io/#download
+[download-actions]: https://github.com/gerbv/gerbv/actions
 
 
 ## About Gerbv
@@ -78,34 +85,26 @@ This is a list of things I hope to be able to fix
 
 ### CMake
 
-First order of business is to use CMake, which is a more modern tool to create builds compared to
-autotools. Autotools were born in an era of diversified releases of different Unix systems.
-Now it is basically Linux everywhere. I have anyhow never liked autotools with its obscure syntax.
+First step was to switch to modern CMake that uses presets and toolchains. There have been kinks
+and surprising stuff, but most things are now in place.
 
-Hopefully it can simplify things like MacOS, Windows and packaging. Since we are using GTK, it
-will probably never be trivial I guess.
+We are now in the CI always compiling and building packages for Debian, Ubuntu, Windows (both cross compiled
+and using MSYS2) and MacOS.
 
-CMake Presets are a thing. Also some sourcecode directory structure can and will probably be
-updated at a later stage.
+There is now a description on [how CMake is used in this project](BUILD.md) that I recommend you to read.
 
 ### Fixing first set of trivial bugs
 
 When I was porting the code to CMake I found a bunch of trivial but serious errors. So I fixed
-them. Upgrading the compiler version have also reveled a number of compilation errors.
+them. Upgrading the compiler version have also revealed a number of compilation errors. Now the code
+compiles cleanly on fairly modern compilers.
 
 ### Packing
 
-Current packing of binaries are zipping it all together. It is always nicer to have the code
-in the - for the operating system/distribution - native way.
+After introducing CMake we are now able to package Debian, Ubuntu and RPMs.
 
-Since we now use CMake we should be able to use the packing support available. For Debian/Ubuntu
-that would mean `.deb` and for Red Hat/Fedora that would mean `.rpm`. When creating the CMake build
-system I spent considerable time to make the install target to be as good as it possible could,
-looking at the Ubuntu/Debian gerbv package as a role model.
-
-For Windows builds we should use the NSIS toolchain. For the Windows packing there is a need for
-distributing all the `.dll` files as well (30+), but my limited experience says it shouldn't be a
-problem.
+For Windows builds we should use the NSIS toolchain, that is WIP to use NSIS. They are currently zipped
+together, but downloading it, unzipping and executing it seems to work.
 
 
 ### More updated Gerber specifications
@@ -116,6 +115,9 @@ as well. Hopefully at least try to parse without warnings on missing syntax.
 
 There is (at least was) a lot of broken Gerber files out there. Just look in the examples directory.
 The question is if it still is so, and if we should support every little quirk, and error or omission.
+
+I have gotten a lot of help in trying to work out all the new Gerbers. It is not all yet, but there are
+a big bunch of PRs still working on to merge in.
 
 ### Port over to GTK-3.0
 
@@ -133,7 +135,7 @@ a frontend using OpenGL is always welcome.
 ### Fixing misunderstandings of the original specification
 
 I am not a graphics guy, I always liked the parsing part more. So from the tiny "standards" paper
-to the full-blown standards paper of today there are bunch of things that has been misunderstood
+to the full-blown standards paper of today there are a bunch of things that has been misunderstood
 or not even implemented.
 
 ### General documentation
@@ -203,7 +205,7 @@ If you want to install it somewhere else, then YMMV.
 For creating Windows binaries, the Fedora distribution is used. It provides all the development libraries
 that is needed for Mingw64 cross compilation, especially GTK2.0+ and Cairo.
 
-Compilation have been tested on Fedora 43 with the following libraries installed:
+Compilation has been tested on Fedora 43 with the following libraries installed:
 * `mingw64-cairo-static`
 * `mingw64-gtk2.static`
 * `cmake`
@@ -212,7 +214,7 @@ Compilation have been tested on Fedora 43 with the following libraries installed
 * `mingw64-gcc-c++`
 * `gettext`
 
-As the binaries are not tested at the moment it might not work or crash horrible. But I would
+As the binaries are not tested at the moment it might not work or crash horribly. But I would
 appreciate any report.
 
 The preset is called `mingw-w64-gcc` and the toolchain file is located in `cmake/toolchains/mingw-w64-gcc.cmake`.
@@ -273,7 +275,7 @@ The problem might only be when running the application locally, but it is hard t
 without being able to run locally. When installing Ubuntu, the first user created is always UID/GID
 1000. 
 
-This problem have been deferred at the moment, running on Ubuntu 22.04 should be good enough for the
+This problem has been deferred at the moment, running on Ubuntu 22.04 should be good enough for the
 time being.
 
 ## Information for developers


### PR DESCRIPTION
I have added a BUILD.md that is supposed to describe on how to build Gerbv.

I have updated the README.md with both a link to the BUILD.md above and an update on things that previously was listed in past presence which is now current. Particularly the CMake system.