### PR TITLE
cosmetic: remove redundant vertex workaround from gerbv_draw_polygon

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -309,9 +309,7 @@ gerbv_draw_polygon(cairo_t *cairoTarget, gdouble outsideDiameter,
 	cairo_move_to(cairoTarget, outsideDiameter / 2.0, 0);
 
 	/* skip first point, since we've moved there already */
-	/* include last point, since we may be drawing an aperture hole next
-	   and cairo may not correctly close the path itself */
-	for (i = 1; i <= (int)numberOfSidesInteger; i++){
+	for (i = 1; i < numberOfSidesInteger; i++){
 	    gdouble angle = ((double)i)*M_PI*2.0 / numberOfSidesInteger;
 	    cairo_line_to (cairoTarget, cos(angle) * outsideDiameter / 2.0,
 		       sin(angle) * outsideDiameter / 2.0);


### PR DESCRIPTION
Closes #433.

## What

`gerbv_draw_polygon` ran its loop with `i <= numberOfSidesInteger` (inclusive), revisiting the first vertex as a zero-length closing segment. The comment said:

> include last point, since we may be drawing an aperture hole next and cairo may not correctly close the path itself

## Why it is now dead code

PR #380 added `cairo_new_sub_path()` at the top of `gerbv_draw_aperture_hole()`. That call starts a fresh subpath before any hole geometry is drawn, which severs the implicit Cairo connection from the polygon endpoint to the hole. The workaround is no longer needed.

## Change

- Loop bound: `i <= numberOfSidesInteger` → `i < numberOfSidesInteger`
- Remove the two comment lines that justified the old bound

No functional change. Golden test images are unaffected and do not need regeneration.