### PR TITLE
cmake: add COMMAND_ERROR_IS_FATAL ANY to configure-time execute_process calls

### DIFF
--- a/cmake/Gettext_helpers.cmake
+++ b/cmake/Gettext_helpers.cmake
@@ -101,7 +101,8 @@ function(configure_gettext)
             COMMAND "${GETTEXT_XGETTEXT_COMMAND}" ${GETTEXT_XGETTEXT_ARGS}
                 ${GETTEXT_SOURCES}
                 "--output=${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
-            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+            COMMAND_ERROR_IS_FATAL ANY)
     endif()
     add_custom_command(
         OUTPUT "${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
@@ -129,7 +130,8 @@ function(configure_gettext)
                     "--input=${GETTEXT_POTFILE_DESTINATION}/${GETTEXT_DOMAIN}.pot"
                     "--output-file=${GETTEXT_POFILE_DESTINATION}/${lang}/${GETTEXT_DOMAIN}.po"
                     "--locale=${lang}"
-                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                COMMAND_ERROR_IS_FATAL ANY)
         endif()
         add_custom_command(
             OUTPUT "${GETTEXT_POFILE_DESTINATION}/${lang}/${GETTEXT_DOMAIN}.po"

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -85,6 +85,7 @@ execute_process(
             -DINPUT_AUTHORS=${CMAKE_SOURCE_DIR}/AUTHORS
             -DOUTPUT_AUTHORS=${CMAKE_CURRENT_BINARY_DIR}/authors.c
             -P ${GENERATOR_SCRIPT_DIR}/generate_headers.cmake
+    COMMAND_ERROR_IS_FATAL ANY
 )
 
 add_custom_command(


### PR DESCRIPTION
Closes #403.

## Problem

The three `execute_process` calls that run at configure time have no failure handling. If any of them exit non-zero, CMake silently continues and the failure surfaces later as a confusing downstream error — the specific example in the issue is an `xgettext` error caused by the header-generation step failing to produce `bugs.c`/`authors.c`.

## Change

Add `COMMAND_ERROR_IS_FATAL ANY` to:
- `config/CMakeLists.txt` — the `generate_headers.cmake` script invocation
- `cmake/Gettext_helpers.cmake` — the `xgettext` `.pot` generation
- `cmake/Gettext_helpers.cmake` — the `msginit` `.po` initialisation

`cmake/GetGitVersion.cmake` is left unchanged; those calls already use `RESULT_VARIABLE` and are intentionally tolerant of `git` not being installed.

`COMMAND_ERROR_IS_FATAL` requires CMake ≥ 3.19; the project's `cmake_minimum_required` is 3.28, so there is no compatibility concern.