### PR TITLE
Add fetch-depth to 0 for all jobs that builds an artifact to be released

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Rebuild Fedora 43
       run: npx --package mini-cross@0.15.2 mc --no-tty fedora_43 .mc/rebuild.sh
@@ -140,6 +142,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Rebuild Ubuntu 22.04
       run: npx --package mini-cross@0.15.2 mc --no-tty ubuntu_22.04 .mc/rebuild.sh
@@ -155,6 +159,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Rebuild Debian 13
       run: npx --package mini-cross@0.15.2 mc --no-tty debian_13 .mc/rebuild.sh
@@ -170,6 +176,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Rebuild Windows amd64 cross compilation
       run: npx --package mini-cross@0.15.2 mc --no-tty windows_amd64 .mc/rebuild-win.sh


### PR DESCRIPTION
When building, the git version tag is used to create a release number. A too shallow git clone will not include the last tags and will create slightly weird version numbers. It said `4.0.0` which `CMakeLists.txt` picks up from the version set when initializing CMake in `project()`.

Switched to 0 for all, which is a complete clone. Most had none from the beginning, which defaults to 1. I tried 50 first, but that was probably too shallow since `develop` is branched of `main` at some point.

