### PR TITLE
Swap config stage and locale stage in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,9 @@ set(PROJECT_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 message(STATUS "Version from git: ${GIT_VERSION}")
 message(STATUS "Parsed version: ${PROJECT_VERSION} (suffix: ${VERSION_SUFFIX})")
 
-add_subdirectory(locale)
+# Note: config must happen before locale, since locale uses config for authors.c/bugs.c 
 add_subdirectory(config)
+add_subdirectory(locale)
 add_subdirectory(src)
 add_subdirectory(man)
 add_subdirectory(desktop)


### PR DESCRIPTION
At a new clone, CMake tried to create the `.pot` files from `authors.c` and `bugs.c`, but they were not created yet. The config stage hadn't run.

The `.pot` files are created in `locale/locale`, so even if you remove the build directory the fail will not be noticed. That is why it failed at clone, but not on subsequent builds.

To see the error you need to run (before this fix)
```
rm -rf locale/locale
rm -rf build
cmake --preset linux-gnu-gcc
```

Was noticed in #438 