### PR TITLE
Fix website rebuild: dedicated ci-website job and replace m4 with shell script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,26 +100,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: gerbv-lcov.info
 
-    - name: Rebuild gerbv.github.io
-      if: ${{ github.ref == 'refs/heads/develop' && !matrix.code_coverage }}
-      run: |
-        npx --package mini-cross@0.15.2 mc --no-tty website make -C gerbv.github.io
-        find gerbv.github.io -type f -name '.gitignore' -exec rm {} \;
-
-    - name: Deploy gerbv.github.io
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        repository-name: gerbv/gerbv.github.io
-        branch: gh-pages
-        folder: gerbv.github.io
-        token: ${{ secrets.GERBV_BUILDBOT_PAT }}
-        git-config-name: gerbv-buildbot
-        git-config-email: violetland+gerbv@mail.ru
-        single-commit: true
-      # @see https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/10
-      env:
-        GERBV_BUILDBOT_PAT: ${{ secrets.GERBV_BUILDBOT_PAT }}
-      if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/develop' && env.GERBV_BUILDBOT_PAT && !matrix.code_coverage }}
 
   ci-fedora:
     runs-on: ubuntu-22.04
@@ -135,7 +115,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: gerbv-fedora
-        path: gerbv.github.io/ci/gerbv*
+        path: gerbv.github.io/ci/
         if-no-files-found: error
 
   ci-ubuntu:
@@ -152,7 +132,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: gerbv-ubuntu
-        path: gerbv.github.io/ci/gerbv*
+        path: gerbv.github.io/ci/
         if-no-files-found: error
 
   ci-debian:
@@ -169,7 +149,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: gerbv-debian
-        path: gerbv.github.io/ci/gerbv*
+        path: gerbv.github.io/ci/
         if-no-files-found: error
 
   ci-windows_amd64-cross:
@@ -186,7 +166,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: gerbv-windows_amd64
-        path: gerbv.github.io/ci/gerbv*
+        path: gerbv.github.io/ci/
         if-no-files-found: error
 
   ci-macos:
@@ -237,7 +217,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: gerbv-macos
-        path: gerbv.github.io/ci/gerbv*
+        path: gerbv.github.io/ci/
         if-no-files-found: error
 
   ci-windows:
@@ -283,8 +263,46 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: gerbv-windows-msys2
-        path: gerbv.github.io/ci/gerbv*
+        path: gerbv.github.io/ci/
         if-no-files-found: error
+
+  ci-website:
+    runs-on: ubuntu-22.04
+    needs: [ci-fedora, ci-debian, ci-ubuntu, ci-windows_amd64-cross, ci-macos, ci-windows]
+    if: ${{ github.ref == 'refs/heads/develop' && github.event_name == 'push' }}
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Download all platform artifacts
+      uses: actions/download-artifact@v6
+      with:
+        pattern: gerbv-*
+        path: gerbv.github.io/ci/
+        merge-multiple: true
+
+    - name: Install doxygen
+      run: |
+        sudo apt-get update
+        sudo apt-get install doxygen
+
+    - name: Build website
+      run: make -C gerbv.github.io
+
+    - name: Deploy gerbv.github.io
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        repository-name: gerbv/gerbv.github.io
+        branch: gh-pages
+        folder: gerbv.github.io
+        token: ${{ secrets.GERBV_BUILDBOT_PAT }}
+        git-config-name: gerbv-buildbot
+        git-config-email: violetland+gerbv@mail.ru
+        single-commit: true
+      env:
+        GERBV_BUILDBOT_PAT: ${{ secrets.GERBV_BUILDBOT_PAT }}
+      # Guard: step is skipped (not failed) when PAT secret is absent
+      if: ${{ env.GERBV_BUILDBOT_PAT != '' }}
+
 
   release:
     runs-on: ubuntu-22.04

--- a/.mc/website.yaml
+++ b/.mc/website.yaml
@@ -2,7 +2,6 @@
 base: ubuntu:22.04
 install:
  - doxygen
- - m4
  - make
 ---
 

--- a/gerbv.github.io/Makefile
+++ b/gerbv.github.io/Makefile
@@ -18,5 +18,5 @@ build:
 	cd '..' && doxygen doc/Doxyfile.nopreprocessing
 	cp -r '../doc/html' 'doc'
 
-	m4 'index.html.m4' > 'index.html'
+	bash generate_index.sh
 

--- a/gerbv.github.io/generate_index.sh
+++ b/gerbv.github.io/generate_index.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Generates index.html from index.html.in by substituting metadata placeholders
+# with values read from ci/ metadata files.
+set -e
+
+sed \
+    -e "s|@FEDORA_43_DATE@|$(tr -d '\n' < 'ci/Fedora 43.RELEASE_DATE')|g" \
+    -e "s|@FEDORA_43_COMMIT@|$(tr -d '\n' < 'ci/Fedora 43.RELEASE_COMMIT')|g" \
+    -e "s|@FEDORA_43_COMMIT_SHORT@|$(tr -d '\n' < 'ci/Fedora 43.RELEASE_COMMIT_SHORT')|g" \
+    -e "s|@FEDORA_43_FILENAME@|$(tr -d '\n' < 'ci/Fedora 43.RELEASE_FILENAME')|g" \
+    -e "s|@UBUNTU_2204_DATE@|$(tr -d '\n' < 'ci/Ubuntu 22.04.RELEASE_DATE')|g" \
+    -e "s|@UBUNTU_2204_COMMIT@|$(tr -d '\n' < 'ci/Ubuntu 22.04.RELEASE_COMMIT')|g" \
+    -e "s|@UBUNTU_2204_COMMIT_SHORT@|$(tr -d '\n' < 'ci/Ubuntu 22.04.RELEASE_COMMIT_SHORT')|g" \
+    -e "s|@UBUNTU_2204_FILENAME@|$(tr -d '\n' < 'ci/Ubuntu 22.04.RELEASE_FILENAME')|g" \
+    -e "s|@DEBIAN_13_DATE@|$(tr -d '\n' < 'ci/Debian 13.RELEASE_DATE')|g" \
+    -e "s|@DEBIAN_13_COMMIT@|$(tr -d '\n' < 'ci/Debian 13.RELEASE_COMMIT')|g" \
+    -e "s|@DEBIAN_13_COMMIT_SHORT@|$(tr -d '\n' < 'ci/Debian 13.RELEASE_COMMIT_SHORT')|g" \
+    -e "s|@DEBIAN_13_FILENAME@|$(tr -d '\n' < 'ci/Debian 13.RELEASE_FILENAME')|g" \
+    -e "s|@WINDOWS_AMD64_DATE@|$(tr -d '\n' < 'ci/Windows amd64.RELEASE_DATE')|g" \
+    -e "s|@WINDOWS_AMD64_COMMIT@|$(tr -d '\n' < 'ci/Windows amd64.RELEASE_COMMIT')|g" \
+    -e "s|@WINDOWS_AMD64_COMMIT_SHORT@|$(tr -d '\n' < 'ci/Windows amd64.RELEASE_COMMIT_SHORT')|g" \
+    -e "s|@WINDOWS_AMD64_FILENAME@|$(tr -d '\n' < 'ci/Windows amd64.RELEASE_FILENAME')|g" \
+    index.html.in > index.html

--- a/gerbv.github.io/index.html.in
+++ b/gerbv.github.io/index.html.in
@@ -67,27 +67,27 @@
          </tr>
          <tr>
            <td style="vertical-align: middle"><img src="assets/Fedora_icon_(2021).svg" alt="Fedora 43" title="Fedora 43" style="height: 100px; box-shadow: none; border: none" /></td>
-           <td style="vertical-align: middle">include(ci/Fedora 43.RELEASE_DATE)</td>
-           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/include(ci/Fedora 43.RELEASE_COMMIT)">include(ci/Fedora 43.RELEASE_COMMIT_SHORT)</a></code></td>
-           <td style="vertical-align: middle"><a class="tar_download_link" href="ci/include(ci/Fedora 43.RELEASE_FILENAME)">Download Fedora 43 binaries</a></td>
+           <td style="vertical-align: middle">@FEDORA_43_DATE@</td>
+           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/@FEDORA_43_COMMIT@">@FEDORA_43_COMMIT_SHORT@</a></code></td>
+           <td style="vertical-align: middle"><a class="tar_download_link" href="ci/@FEDORA_43_FILENAME@">Download Fedora 43 binaries</a></td>
          </tr>
          <tr>
            <td style="vertical-align: middle"><img src="assets/cof_orange_hex.png" alt="Ubuntu 22.04" title="Ubuntu 22.04" style="height: 100px; box-shadow: none; border: none" /></td>
-           <td style="vertical-align: middle">include(ci/Ubuntu 22.04.RELEASE_DATE)</td>
-           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/include(ci/Ubuntu 22.04.RELEASE_COMMIT)">include(ci/Ubuntu 22.04.RELEASE_COMMIT_SHORT)</a></code></td>
-           <td style="vertical-align: middle"><a class="tar_download_link" href="ci/include(ci/Ubuntu 22.04.RELEASE_FILENAME)">Download Ubuntu 22.04 binaries</a></td>
+           <td style="vertical-align: middle">@UBUNTU_2204_DATE@</td>
+           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/@UBUNTU_2204_COMMIT@">@UBUNTU_2204_COMMIT_SHORT@</a></code></td>
+           <td style="vertical-align: middle"><a class="tar_download_link" href="ci/@UBUNTU_2204_FILENAME@">Download Ubuntu 22.04 binaries</a></td>
          </tr>
          <tr>
            <td style="vertical-align: middle"><img src="assets/Debian-OpenLogo.svg" alt="Debian 13" title="Debian 13" style="height: 100px; box-shadow: none; border: none" /></td>
-           <td style="vertical-align: middle">include(ci/Debian 13.RELEASE_DATE)</td>
-           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/include(ci/Debian 13.RELEASE_COMMIT)">include(ci/Debian 13.RELEASE_COMMIT_SHORT)</a></code></td>
-           <td style="vertical-align: middle"><a class="tar_download_link" href="ci/include(ci/Debian 13.RELEASE_FILENAME)">Download Debian 13 binaries</a></td>
+           <td style="vertical-align: middle">@DEBIAN_13_DATE@</td>
+           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/@DEBIAN_13_COMMIT@">@DEBIAN_13_COMMIT_SHORT@</a></code></td>
+           <td style="vertical-align: middle"><a class="tar_download_link" href="ci/@DEBIAN_13_FILENAME@">Download Debian 13 binaries</a></td>
          </tr>
          <tr>
            <td style="vertical-align: middle"><img src="assets/Windows_10_Logo.png" alt="Windows amd64" title="Windows amd64" style="height: 100px; box-shadow: none; border: none" /></td>
-           <td style="vertical-align: middle">include(ci/Windows amd64.RELEASE_DATE)</td>
-           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/include(ci/Windows amd64.RELEASE_COMMIT)">include(ci/Windows amd64.RELEASE_COMMIT_SHORT)</a></code></td>
-           <td style="vertical-align: middle"><a class="zip_download_link" href="ci/include(ci/Windows amd64.RELEASE_FILENAME)">Download Windows amd64 binaries</a></td>
+           <td style="vertical-align: middle">@WINDOWS_AMD64_DATE@</td>
+           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/@WINDOWS_AMD64_COMMIT@">@WINDOWS_AMD64_COMMIT_SHORT@</a></code></td>
+           <td style="vertical-align: middle"><a class="zip_download_link" href="ci/@WINDOWS_AMD64_FILENAME@">Download Windows amd64 binaries</a></td>
          </tr>
        </table>
 


### PR DESCRIPTION
Add a dedicated ci-website job that runs after all platform builds and downloads their artifacts (including metadata files) before generating index.html. Replace fragile m4 macro processing with a plain sed-based shell script (generate_index.sh) and rename index.html.m4 to index.html.in with @PLACEHOLDER@ markers. Fix artifact upload paths from gerbv* glob to full ci/ directory so metadata files are captured.

This will at least not fail in the pipeline when merging into the development branch. Even though it will probably not update the website due to a key problem.