### PR TITLE
Switch website deploy to SSH deploy key, drop PAT and real email

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,14 +294,14 @@ jobs:
         repository-name: gerbv/gerbv.github.io
         branch: gh-pages
         folder: gerbv.github.io
-        token: ${{ secrets.GERBV_BUILDBOT_PAT }}
+        ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
         git-config-name: gerbv-buildbot
-        git-config-email: violetland+gerbv@mail.ru
+        git-config-email: gerbv-buildbot@users.noreply.github.com
         single-commit: true
       env:
-        GERBV_BUILDBOT_PAT: ${{ secrets.GERBV_BUILDBOT_PAT }}
-      # Guard: step is skipped (not failed) when PAT secret is absent
-      if: ${{ env.GERBV_BUILDBOT_PAT != '' }}
+        PAGES_DEPLOY_KEY: ${{ secrets.PAGES_DEPLOY_KEY }}
+      # Guard: step is skipped (not failed) when deploy key secret is absent
+      if: ${{ env.PAGES_DEPLOY_KEY != '' }}
 
 
   release:


### PR DESCRIPTION
Replace the GERBV_BUILDBOT_PAT personal access token with a scoped SSH deploy key (PAGES_DEPLOY_KEY secret) for cross-repo deployment to gerbv/gerbv.github.io. Use GitHub's no-reply email for the bot commit author so no real address appears in config files.

A fix to #448, but will issue if this fails.