### PR TITLE
Do not install all libraries in ci-macos.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,9 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        brew install cmake ninja pkgconf gettext gtk+ gtkmm libffi zlib bzip2 libpng expat imagemagick
+        # These packages are already installed. We comment them out to avoid warnings
+        # brew install cmake ninja pkgconf libpng gettext
+        brew install gtk+ gtkmm libffi zlib bzip2 expat imagemagick
         echo "PATH=$(brew --prefix gettext)/bin:${PATH}" >> $GITHUB_ENV
         mkdir -p "${HOME}/.local/lib/pkgconfig"
         BZIP_PREFIX="$(brew --prefix bzip2)"


### PR DESCRIPTION
They caused warnings in CI builds since they were already installed.

Reduce noise in build logs.