### PR TITLE
docs: GTK2 deprecation — plan migration from GdkColor to standalone color type

### DIFF
--- a/GTK2_DEPRECATION.md
+++ b/GTK2_DEPRECATION.md
@@ -1,0 +1,82 @@
+# GTK2 Deprecation in libgerbv
+
+## Status
+
+GTK2 is **end-of-life** as of GTK3 (December 2020). GTK4 is the current stable release.
+libgerbv still depends on GTK2 for its GUI and uses `GdkColor` (16-bit RGB) in its public API.
+
+## Impact on libgerbv
+
+### API Surface Issues
+
+1. **`gerbv.h:73`** — `#include <gtk/gtk.h>` pulls in all of GTK2, even for headless/library-only usage
+2. **`GdkColor` in public structs** — `gerbv_fileinfo_t.color` and `gerbv_project_t.background` use `GdkColor` which:
+   - Has no alpha channel (alpha is a separate `gushort` field on `gerbv_fileinfo_t`)
+   - Uses 16-bit color values (0-65535) instead of normalized floats
+   - Is deprecated in GTK3 in favor of `GdkRGBA` (float RGBA)
+3. **`gerbv_render_layer_to_cairo_target()`** — the Cairo rendering path doesn't need GTK at all, but the header forces GTK2 linkage
+
+### Compilation Warnings (GLib 2.88+)
+
+```
+gtktypeutils.h:236: 'GTypeDebugFlags' is deprecated
+gtktooltips.h:73: 'GTimeVal' is deprecated: Use 'GDateTime' instead
+```
+
+These are harmless but noisy. Suppressed with `-w` in practice.
+
+## Proposed Fix: Split libgerbv from GTK2
+
+### Phase 1: Decouple header (non-breaking)
+
+Replace `GdkColor` in `gerbv.h` with a standalone color struct:
+
+```c
+/* New: standalone color type, no GTK dependency */
+typedef struct {
+    double red;    /* 0.0 - 1.0 */
+    double green;  /* 0.0 - 1.0 */
+    double blue;   /* 0.0 - 1.0 */
+    double alpha;  /* 0.0 - 1.0 */
+} gerbv_color_t;
+```
+
+Update `gerbv_fileinfo_t` and `gerbv_project_t` to use `gerbv_color_t`.
+Provide backward-compat macros for existing code using `GdkColor`.
+
+### Phase 2: Remove GTK include from gerbv.h
+
+Move `#include <gtk/gtk.h>` into the GUI source files only (`src/main.c`, `src/callbacks.c`, etc.).
+`gerbv.h` should only need `<glib.h>` (for `gboolean`, `gchar`, etc.) and `<cairo.h>`.
+
+### Phase 3: Optional GTK-free build
+
+Add a CMake/Meson option to build libgerbv without GTK:
+
+```
+-DGERBV_HEADLESS=ON  # Build libgerbv only, no GUI
+```
+
+This is the common use case for server-side rendering (e.g., Source Parts API).
+
+## Workaround (current)
+
+In `gerbv-render.c` (Parts Studio tools):
+
+```c
+/* GdkColor uses 16-bit values (0-65535), not floats */
+project->file[f]->color.red = ((color >> 24) & 0xFF) * 257;
+project->file[f]->color.green = ((color >> 16) & 0xFF) * 257;
+project->file[f]->color.blue = ((color >> 8) & 0xFF) * 257;
+project->file[f]->alpha = (gushort)(((color) & 0xFF) * 257);
+```
+
+Alpha is a separate field on `gerbv_fileinfo_t`, not part of `GdkColor`.
+
+## References
+
+- [GTK 2.x EOL announcement](https://blog.gtk.org/)
+- [GdkRGBA documentation](https://docs.gtk.org/gdk3/struct.RGBA.html)
+- [Cairo standalone usage](https://www.cairographics.org/)
+- [gerbv upstream repo](https://github.com/gerbv/gerbv)
+- [SourceParts fork](https://github.com/SourceParts/gerbv)

--- a/GTK2_DEPRECATION.md
+++ b/GTK2_DEPRECATION.md
@@ -27,22 +27,24 @@ These are harmless but noisy. Suppressed with `-w` in practice.
 
 ## Proposed Fix: Split libgerbv from GTK2
 
-### Phase 1: Decouple header (non-breaking)
+### Phase 1: Decouple header (non-breaking) — **Implemented**
 
-Replace `GdkColor` in `gerbv.h` with a standalone color struct:
+Added `gerbv_color_t` standalone RGBA color type to `gerbv.h` (normalized floats 0.0–1.0):
 
 ```c
-/* New: standalone color type, no GTK dependency */
 typedef struct {
-    double red;    /* 0.0 - 1.0 */
-    double green;  /* 0.0 - 1.0 */
-    double blue;   /* 0.0 - 1.0 */
-    double alpha;  /* 0.0 - 1.0 */
+    double red;
+    double green;
+    double blue;
+    double alpha;
 } gerbv_color_t;
 ```
 
-Update `gerbv_fileinfo_t` and `gerbv_project_t` to use `gerbv_color_t`.
-Provide backward-compat macros for existing code using `GdkColor`.
+Added backward-compatibility macros `GERBV_COLOR_FROM_GDK()` and `GERBV_COLOR_TO_GDK()`
+for converting between `GdkColor` (16-bit) and `gerbv_color_t` (float).
+
+Existing `GdkColor` fields in `gerbv_fileinfo_t` and `gerbv_project_t` are **unchanged**
+(no ABI break). The new type and macros provide a migration path for Phase 2.
 
 ### Phase 2: Remove GTK include from gerbv.h
 

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -731,6 +731,28 @@ typedef struct {
   gerbv_drill_stats_t *drill_stats;  /*!< Excellon drill statistics for the layer */
 } gerbv_image_t;
 
+/** Standalone RGBA color type — no GTK dependency.
+ *  Values are normalized floats 0.0–1.0.
+ *  Added to replace GdkColor which has no alpha and requires GTK headers.
+ */
+typedef struct {
+    double red;
+    double green;
+    double blue;
+    double alpha;
+} gerbv_color_t;
+
+/** Convert GdkColor (16-bit) + alpha to gerbv_color_t (float) */
+#define GERBV_COLOR_FROM_GDK(gdk, a) \
+    ((gerbv_color_t){ (gdk).red / 65535.0, (gdk).green / 65535.0, (gdk).blue / 65535.0, (a) / 65535.0 })
+
+/** Convert gerbv_color_t (float) to GdkColor (16-bit) */
+#define GERBV_COLOR_TO_GDK(c, gdk) do { \
+    (gdk).red = (guint16)((c).red * 65535.0);   \
+    (gdk).green = (guint16)((c).green * 65535.0); \
+    (gdk).blue = (guint16)((c).blue * 65535.0);   \
+} while(0)
+
 /*!  Holds information related to an individual layer that is part of a project */
 typedef struct {
   gerbv_image_t *image; /*!< the image holding all the geometry of the layer */


### PR DESCRIPTION
## Summary

GTK2 is end-of-life. libgerbv's public API (`gerbv.h`) still depends on GTK2 via `#include <gtk/gtk.h>` and uses `GdkColor` (16-bit RGB, no alpha) in its public structs.

This PR adds documentation outlining the issue and a 3-phase migration plan.

## Problems

1. **`gerbv.h:73`** includes all of GTK2, even for headless/library-only usage
2. **`GdkColor`** in `gerbv_fileinfo_t.color` and `gerbv_project_t.background`:
   - No alpha channel (alpha is a separate `gushort` field)
   - 16-bit values (0-65535) instead of normalized floats
   - Deprecated in GTK3 in favor of `GdkRGBA`
3. **Cairo rendering** (`gerbv_render_layer_to_cairo_target`) doesn't need GTK at all, but the header forces linkage
4. **GLib 2.88+ warnings**: `GTypeDebugFlags` and `GTimeVal` deprecation warnings from GTK2 headers

## Proposed Fix (3 phases)

### Phase 1: Standalone color type (non-breaking)
```c
typedef struct {
    double red;    /* 0.0 - 1.0 */
    double green;  /* 0.0 - 1.0 */
    double blue;   /* 0.0 - 1.0 */
    double alpha;  /* 0.0 - 1.0 */
} gerbv_color_t;
```
Replace `GdkColor` in public structs. Provide backward-compat macros.

### Phase 2: Remove GTK from gerbv.h
Move `#include <gtk/gtk.h>` into GUI sources only. Header needs only `<glib.h>` + `<cairo.h>`.

### Phase 3: Headless build option
`-DGERBV_HEADLESS=ON` to build libgerbv without GTK (common for server-side rendering).

## Context

We maintain a [fork](https://github.com/SourceParts/gerbv) and use libgerbv for server-side Gerber rendering (Cairo → PNG) in our electronics platform. The GTK2 dependency is the main friction point for headless/embedded usage.