### PR TITLE
Also add the MacOS and Windows MSYS2 artifacts to the webpage.

### DIFF
--- a/gerbv.github.io/generate_index.sh
+++ b/gerbv.github.io/generate_index.sh
@@ -20,4 +20,12 @@ sed \
     -e "s|@WINDOWS_AMD64_COMMIT@|$(tr -d '\n' < 'ci/Windows amd64.RELEASE_COMMIT')|g" \
     -e "s|@WINDOWS_AMD64_COMMIT_SHORT@|$(tr -d '\n' < 'ci/Windows amd64.RELEASE_COMMIT_SHORT')|g" \
     -e "s|@WINDOWS_AMD64_FILENAME@|$(tr -d '\n' < 'ci/Windows amd64.RELEASE_FILENAME')|g" \
+    -e "s|@WINDOWS_MSYS2_DATE@|$(tr -d '\n' < 'ci/Windows MSYS2 UCRT64.RELEASE_DATE')|g" \
+    -e "s|@WINDOWS_MSYS2_COMMIT@|$(tr -d '\n' < 'ci/Windows MSYS2 UCRT64.RELEASE_COMMIT')|g" \
+    -e "s|@WINDOWS_MSYS2_COMMIT_SHORT@|$(tr -d '\n' < 'ci/Windows MSYS2 UCRT64.RELEASE_COMMIT_SHORT')|g" \
+    -e "s|@WINDOWS_MSYS2_FILENAME@|$(tr -d '\n' < 'ci/Windows MSYS2 UCRT64.RELEASE_FILENAME')|g" \
+    -e "s|@MACOS_DATE@|$(tr -d '\n' < 'ci/macOS.RELEASE_DATE')|g" \
+    -e "s|@MACOS_COMMIT@|$(tr -d '\n' < 'ci/macOS.RELEASE_COMMIT')|g" \
+    -e "s|@MACOS_COMMIT_SHORT@|$(tr -d '\n' < 'ci/macOS.RELEASE_COMMIT_SHORT')|g" \
+    -e "s|@MACOS_FILENAME@|$(tr -d '\n' < 'ci/macOS.RELEASE_FILENAME')|g" \
     index.html.in > index.html

--- a/gerbv.github.io/index.html.in
+++ b/gerbv.github.io/index.html.in
@@ -89,6 +89,18 @@
            <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/@WINDOWS_AMD64_COMMIT@">@WINDOWS_AMD64_COMMIT_SHORT@</a></code></td>
            <td style="vertical-align: middle"><a class="zip_download_link" href="ci/@WINDOWS_AMD64_FILENAME@">Download Windows amd64 binaries</a></td>
          </tr>
+         <tr>
+           <td style="vertical-align: middle"><img src="assets/Windows_10_Logo.png" alt="Windows MSYS2 UCRT64" title="Windows MSYS2 UCRT64" style="height: 100px; box-shadow: none; border: none" /></td>
+           <td style="vertical-align: middle">@WINDOWS_MSYS2_DATE@</td>
+           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/@WINDOWS_MSYS2_COMMIT@">@WINDOWS_MSYS2_COMMIT_SHORT@</a></code></td>
+           <td style="vertical-align: middle"><a class="zip_download_link" href="ci/@WINDOWS_MSYS2_FILENAME@">Download Windows MSYS2 UCRT64 binaries</a></td>
+         </tr>
+         <tr>
+           <td style="vertical-align: middle">macOS</td>
+           <td style="vertical-align: middle">@MACOS_DATE@</td>
+           <td style="vertical-align: middle"><code><a href="https://github.com/gerbv/gerbv/tree/@MACOS_COMMIT@">@MACOS_COMMIT_SHORT@</a></code></td>
+           <td style="vertical-align: middle"><a class="zip_download_link" href="ci/@MACOS_FILENAME@">Download macOS binaries</a></td>
+         </tr>
        </table>
 
       </section>


### PR DESCRIPTION
The icon for the Windows MSYS2 is the same as for Windows AMD64.
For MacOS there is no icon at the moment. Need to dig up one.