### PR TITLE
Update install presets

### DIFF
--- a/.mc/debian_13/opt/configure.sh
+++ b/.mc/debian_13/opt/configure.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-cmake --preset linux-gnu-gcc-install
+cmake --preset linux-gnu-gcc-opt

--- a/.mc/fedora_43/opt/configure.sh
+++ b/.mc/fedora_43/opt/configure.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-cmake --preset linux-gnu-gcc-install
-
+cmake --preset linux-gnu-gcc-opt

--- a/.mc/ubuntu_22.04/opt/configure.sh
+++ b/.mc/ubuntu_22.04/opt/configure.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-cmake --preset linux-gnu-gcc-install
+cmake --preset linux-gnu-gcc-opt

--- a/BUILD.md
+++ b/BUILD.md
@@ -30,12 +30,22 @@ rm -rf build
 cmake --preset linux-gnu-gcc
 cmake --build --preset linux-gnu-gcc
 ```
-Binary is now in `build/src/Debug/gerbv`
+Binary is now in `build/src/Debug/gerbv`. If you run `cmake --install build` it will install
+everything in `/usr/local/`.
+
+Building locally on a Linux/GCC based machine to install to `/usr/`:
+```
+rm -rf build
+cmake --preset linux-gnu-gcc-usr
+cmake --build --preset linux-gnu-gcc
+sudo cmake --install build/
+```
+Binary is Debug version. It will install everything in `/usr/`.
 
 Building a Debian package to install using `dpkg -i`
 ```
 rm -rf build
-cmake --preset linux-gnu-gcc-install
+cmake --preset linux-gnu-gcc-opt
 cmake --build --preset linux-gnu-gcc-release
 cpack --preset deb-opt
 sudo dpkg -i _packages/gerbv<Something>.deb
@@ -81,19 +91,20 @@ Doing `cmake --list-presets` in Gerbv gives (at the time of writing)
 $ cmake --list-presets
 Available configure presets:
 
-  "linux-gnu-gcc"
-  "linux-gnu-gcc-install"
-  "macos-clang"
-  "mingw-w64-gcc"
-  "msys2-ucrt64-gcc"
+  "linux-gnu-gcc"     - Linux/GCC. Installs in /usr/local/
+  "linux-gnu-gcc-opt" - Linux/GCC. Installs in /opt/gerbv.github/
+  "linux-gnu-gcc-usr" - Linux/GCC. Installs in /usr/
+  "macos-clang"       - macOS/Clang
+  "mingw-w64-gcc"     - MinGW cross compiled
+  "msys2-ucrt64-gcc"  - MSYS2 native Windows
 ```
-Here are the different platforms listed. The difference between `linux-gnu-gcc` and `linux-gnu-gcc-install` is
-that CMake requires you to set the installation directory already in the configuration stage. So `linux-gnu-gcc-install`
+Here are the different platforms listed. The difference between `linux-gnu-gcc` and `linux-gnu-gcc-opt` is
+that CMake requires you to set the installation directory already in the configuration stage. So `linux-gnu-gcc-opt`
 sets the install directory to `/opt/gerbv.github/`, since that is a requirement for thirdparty packages in Debian.
 
 **Note** We don't say anything about `Debug` or `Release` build here, since we are using the `Ninja Multi-Config` generator.
 
-After configuration you should have a `build` directory, and in that there should be a `compile_commands.json` that
+After configuration you should have a `build` directory, and in there there should be a `compile_commands.json` that
 describes all flags that will be used when compiling. There should also be the generated `build/config/config.h`, which is
 the generated configuration file used throughout the project. Those two files can be used to check that all the
 compilation flags and defines have been set properly.
@@ -115,16 +126,16 @@ Doing `cmake --build --list-presets` after the previous configuration stage give
 $ cmake --build --list-presets
 Available build presets:
 
-  "linux-gnu-gcc"
-  "linux-gnu-gcc-release"
-  "macos-clang"
-  "macos-clang-release"
+  "linux-gnu-gcc"            - Build debug
+  "linux-gnu-gcc-release"    - Build release
+  "macos-clang"              - macOS/Clang debug
+  "macos-clang-release"      - macOS/Clang release
   "mingw-w64-gcc"
   "mingw-w64-gcc-release"
   "msys2-ucrt64-gcc"
   "msys2-ucrt64-gcc-release"
 ```
-Here we define if we should do a `Debug` or a `Release` build. Default is, as you probably understand, `Debug`.
+Here we define if we want to do a `Debug` or a `Release` build. Default is, as you probably understand, `Debug`.
 The build `RelWithDebInfo` is not used by us at the moment.
 
 #### Test presets in Gerbv

--- a/cmake/preset/linux-gnu-gcc.json
+++ b/cmake/preset/linux-gnu-gcc.json
@@ -4,25 +4,42 @@
     "configurePresets": [
         {
             "name": "linux-gnu-gcc",
+            "displayName": "Linux/GCC. Installs in /usr/local/",
+            "description": "Linux build with GCC. Installs in /usr/local/, default",
             "inherits": "base",
             "toolchainFile": "cmake/toolchains/linux-gnu-gcc.cmake"
         },
         {
-            "name": "linux-gnu-gcc-install",
+            "name": "linux-gnu-gcc-opt",
+            "displayName": "Linux/GCC. Installs in /opt/gerbv.github/",
+            "description": "Linux build with GCC. Installs in /opt/gerbv.github/",
             "inherits": "linux-gnu-gcc",
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "/opt/gerbv.github/"
+            }
+        },
+        {
+            "name": "linux-gnu-gcc-usr",
+            "displayName": "Linux/GCC. Installs in /usr/",
+            "description": "Linux build with GCC. Installs in /usr/",
+            "inherits": "linux-gnu-gcc",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "/usr/"
             }
         }
     ],
     "buildPresets": [
         {
             "name": "linux-gnu-gcc",
+            "displayName": "Build debug",
+            "description": "Debug build, default",
             "configurePreset": "linux-gnu-gcc",
             "configuration": "Debug"
         },
         {
             "name": "linux-gnu-gcc-release",
+            "displayName": "Build release",
+            "description": "Release build",
             "configurePreset": "linux-gnu-gcc",
             "configuration": "Release"
         }
@@ -48,7 +65,7 @@
         },
         {
             "name": "deb-opt",
-            "configurePreset": "linux-gnu-gcc-install",
+            "configurePreset": "linux-gnu-gcc-opt",
             "generators": [
                 "DEB"
             ],
@@ -68,7 +85,7 @@
         },
         {
             "name": "rpm-opt",
-            "configurePreset": "linux-gnu-gcc-install",
+            "configurePreset": "linux-gnu-gcc-opt",
             "generators": [
                 "RPM"
             ],

--- a/cmake/preset/macos-clang.json
+++ b/cmake/preset/macos-clang.json
@@ -4,6 +4,7 @@
     "configurePresets": [
         {
             "name": "macos-clang",
+            "displayName": "macOS/Clang",
             "inherits": "base",
             "binaryDir": "build-macos-clang",
             "cacheVariables": {
@@ -15,11 +16,13 @@
     "buildPresets": [
         {
             "name": "macos-clang",
+            "displayName": "macOS/Clang debug",
             "configurePreset": "macos-clang",
             "configuration": "Debug"
         },
         {
             "name": "macos-clang-release",
+            "displayName": "macOS/Clang release",
             "configurePreset": "macos-clang",
             "configuration": "Release"
         }

--- a/cmake/preset/mingw-w64-gcc.json
+++ b/cmake/preset/mingw-w64-gcc.json
@@ -4,6 +4,7 @@
     "configurePresets": [
         {
             "name": "mingw-w64-gcc",
+            "displayName": "MinGW cross compiled",
             "inherits": "base",
             "toolchainFile": "cmake/toolchains/mingw-w64-gcc.cmake"
         }

--- a/cmake/preset/msys2-ucrt64-gcc.json
+++ b/cmake/preset/msys2-ucrt64-gcc.json
@@ -4,6 +4,7 @@
     "configurePresets": [
         {
             "name": "msys2-ucrt64-gcc",
+            "displayName": "MSYS2 native Windows",
             "inherits": "base",
             "toolchainFile": "cmake/toolchains/msys2-ucrt64-gcc.cmake"
         }


### PR DESCRIPTION
Created more presets and documented the existing ones
    
Renamed linux-gnu-gcc-install to linux-gnu-gcc-opt to described that it  is installed to /opt/gerbv.github
Added linux-gnu-gcc-usr to describe that it is installed to /usr.
Added displayName and desription text to describe what its intention is.
Updated the pipeline builds to use the new configuration preset names.

Updated displayName and description on configure for    
* Windows-MinGW
* Windows-MSYS2
* MacOS

Improved BUILD description with new presets and added warning for slightly outdated install docs.