### PR TITLE
Fallback on CMake version if no git

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,24 @@ on:
 
 
 jobs:
+  check-version:
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check CMakeLists.txt VERSION matches git tag
+        run: |
+          CMAKE_VERSION=$(grep -oP 'project\s*\(\s*gerbv\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+          TAG_VERSION="${{ github.ref_name }}"
+          TAG_BASE="${TAG_VERSION#v}"
+          TAG_BASE="${TAG_BASE%%-*}"
+          if [ "$CMAKE_VERSION" != "$TAG_BASE" ]; then
+            echo "ERROR: CMakeLists.txt VERSION (${CMAKE_VERSION}) does not match git tag (${TAG_VERSION})"
+            echo "Please update VERSION in CMakeLists.txt before tagging a release."
+            exit 1
+          fi
+          echo "Version check passed: ${CMAKE_VERSION} matches tag ${TAG_VERSION}"
+
   ci-ubuntu-22-04:
     runs-on: ubuntu-22.04
     strategy:
@@ -308,7 +326,7 @@ jobs:
 
   release:
     runs-on: ubuntu-22.04
-    needs: [ci-ubuntu-22-04, ci-fedora, ci-debian, ci-ubuntu, ci-windows_amd64-cross, ci-macos, ci-windows]
+    needs: [check-version, ci-ubuntu-22-04, ci-fedora, ci-debian, ci-ubuntu, ci-windows_amd64-cross, ci-macos, ci-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.28)
 
+# Update the release version here for when the code is built out
+# of tree. It is not optimal, but that how it is. There is a check
+# in the release build to make sure this version and the tag have
+# the same version.
 project(gerbv
-        VERSION 4.0
+        VERSION 2.13.0
         DESCRIPTION "Gerber Viewer"
         LANGUAGES C CXX)
 


### PR DESCRIPTION
If Git is not installed the CMake process falls back to the version in `project()` in `CMakeLists.txt`.

Though we always build releases with using `git tag` we need to get the version into the GitHub source tar ball. How the source tarballs are created is not in our control. So we need to trick a version into there, but at the same time make sure all versions are the same. We now have two versions of truth and we need to make sure that they agree.

So now there is a little extra job that runs at release that checks that the versions are the same. The actual release job then depends on that the "check job" does not fail before starting the actual release process. That way we can hopefully avoid making a release where the two version numbers differs.

Closes #454 