### PR TITLE
Add back installation of libgerbv.pc in Windows since it is apparentl…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,5 @@ set(includedir "\$\{prefix\}/${CMAKE_INSTALL_INCLUDEDIR}")
 set(PACKAGE ${PROJECT_NAME})
 configure_file(libgerbv.pc.in libgerbv.pc @ONLY)
 
-if(NOT WIN32)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libgerbv.pc
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-endif()
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libgerbv.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
…y used.

It was removed from Windows build in #462 since it is not common for Windows to use it.

Closes #463 .