### PR TITLE
fix: use GSettings keyfile backend on Windows

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -48,6 +48,10 @@
 
 #include "draw.h"
 
+#ifdef WIN32
+#include <gio/gsettingsbackend.h>
+#endif
+
 #include "gerbv_icon.h"
 #include "icons.h"
 
@@ -348,7 +352,32 @@ interface_create_gui (int req_width, int req_height)
 
 	if (NULL != settings_schema) {
 		g_settings_schema_unref(settings_schema);
+#ifdef WIN32
+		/* Use the keyfile backend on Windows instead of the default
+		 * registry backend.  GLib 2.69+ changed the Windows GSettings
+		 * backend to use registry watching, which busy-loops on
+		 * Windows 7 and causes 100% CPU usage.  The keyfile backend
+		 * stores settings in a plain INI file in %APPDATA% and works
+		 * on all Windows versions.
+		 * See: https://github.com/gerbv/gerbv/issues/457 */
+		{
+			gchar *config_dir = g_build_filename(
+			    g_get_user_config_dir(), "gerbv", NULL);
+			g_mkdir_with_parents(config_dir, 0755);
+			gchar *config_path = g_build_filename(
+			    config_dir, "settings.ini", NULL);
+			GSettingsBackend *backend =
+			    g_keyfile_settings_backend_new(
+				config_path, "/org/geda-user/gerbv/", NULL);
+			screen.settings = g_settings_new_with_backend(
+			    settings_id, backend);
+			g_object_unref(backend);
+			g_free(config_path);
+			g_free(config_dir);
+		}
+#else
 		screen.settings = g_settings_new(settings_id);
+#endif
 	}
 
 	pointerpixbuf = pixbuf_from_icon(&pointer);

--- a/src/interface.c
+++ b/src/interface.c
@@ -49,6 +49,7 @@
 #include "draw.h"
 
 #ifdef WIN32
+#define G_SETTINGS_ENABLE_BACKEND
 #include <gio/gsettingsbackend.h>
 #endif
 


### PR DESCRIPTION
## Summary

Fixes #457 — 100% CPU on Windows 7 caused by GLib's registry-based GSettings backend busy-looping.

GLib 2.69+ changed the Windows GSettings backend from file-based to registry-based. The registry watcher busy-loops on Windows 7, causing 100% CPU immediately on launch. This happened between gerbv v2.8.0 (GLib 2.68.x, file-based) and v2.8.1 (GLib 2.69.2, registry-based).

The fix switches to the GSettings **keyfile backend** on **all Windows versions**, which stores settings in a plain INI file at `%APPDATA%/gerbv/settings.ini` instead of the Windows registry.

### Why keyfile on all Windows, not just Windows 7

The registry backend's only advantage is cross-process settings synchronization — one app writes a setting, another app sees it instantly. gerbv doesn't need this; it's a single-process desktop app reading its own preferences.

The keyfile backend is strictly better for gerbv:
- No background registry watcher thread consuming resources
- Human-readable INI file users can inspect and edit
- More portable if users copy their config between machines
- Works identically on Windows 7, 10, and 11
- Full settings persistence (window state, rendering mode, display units)
- All existing `g_settings_bind()` calls work unchanged — no API changes needed

Single file change: `src/interface.c` — 29 lines added, all guarded by `#ifdef WIN32`.

## Test plan

- [x] Builds clean with `-Werror` on Linux
- [x] No new test regressions (same 11 pre-existing golden-file mismatches)
- [ ] Verify on Windows 7: CPU stays normal on launch
- [ ] Verify on Windows 10/11: settings persist between sessions in `%APPDATA%/gerbv/settings.ini`
- [ ] Verify settings round-trip: change rendering mode, close, reopen — setting should persist