### PR TITLE
fix: memory leaks in gerbv_image_duplicate_image

### DIFF
--- a/src/gerb_image.c
+++ b/src/gerb_image.c
@@ -924,6 +924,16 @@ gerbv_image_duplicate_image (gerbv_image_t *sourceImage, gerbv_user_transformati
     GArray *apertureNumberTable = g_array_new(FALSE,FALSE,sizeof(gerb_translation_entry_t));
     
     newImage->layertype = sourceImage->layertype;
+
+    /* Free the type string allocated by gerbv_create_image() before the
+     * struct copy overwrites the pointer (would leak otherwise). */
+    g_free(newImage->info->type);
+
+    /* Free the sentinel netlist node — gerbv_image_copy_all_nets() will
+     * replace newImage->netlist with a fresh copy of the source nets. */
+    g_free(newImage->netlist);
+    newImage->netlist = NULL;
+
     /* copy information layer over */
     *(newImage->info) = *(sourceImage->info);
     newImage->info->name = g_strdup (sourceImage->info->name);


### PR DESCRIPTION
## Summary

Fix two memory leaks in `gerbv_image_duplicate_image()` (`src/gerb_image.c`) triggered whenever an image is duplicated — e.g. during RS274-X export via `gerbv_export_rs274x_file_from_image`.

**Leak 1 (22 bytes)**: `gerbv_create_image()` allocates `info->type = g_strdup(type)`. The struct copy `*(newImage->info) = *(sourceImage->info)` overwrites the pointer without freeing it, then line 930 allocates a new copy.

**Leak 2 (128 bytes)**: `gerbv_create_image()` allocates a sentinel `netlist` node. `gerbv_image_copy_all_nets()` replaces `newImage->netlist` with a fresh copy of the source nets (line 495), orphaning the original sentinel.

Fix: free both the type string and sentinel netlist node before the struct copy.

## Verification

Valgrind before fix:
```
definitely lost: 150 bytes in 2 blocks
```

Valgrind after fix:
```
definitely lost: 0 bytes in 0 blocks
```

Tested with a parse → export → destroy round-trip using `test/inputs/test-gerber-x2-attributes.gbx`.

## Test plan

- [x] Builds clean with `-Werror`
- [x] No new test regressions (same 11 pre-existing golden-file mismatches)
- [x] Valgrind: 0 definitely lost bytes on export round-trip path
- [x] Valgrind: 0 definitely lost bytes on parse+destroy path