### PR TITLE
fix: enable destroy_paths() cleanup via atexit

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -392,15 +392,10 @@ static char *exec_prefix = NULL;
 static char *pkgdatadir = NULL;
 static gchar *scmdatadir = NULL;
 
-/* this really should not be needed but it could
- * be hooked in to appease malloc debuggers as
- * we don't otherwise free these variables.  However,
- * they only get malloc-ed once ever so this
- * is a fixed leak of a small size.
- */
-#if 0
-void
-destroy_paths ()
+/** Free static path strings allocated by init_paths().
+ * Registered via atexit() so valgrind reports zero leaks. */
+static void
+destroy_paths (void)
 {
   if (bindir != NULL) {
     free (bindir);
@@ -421,10 +416,7 @@ destroy_paths ()
     g_free (scmdatadir);
     scmdatadir = NULL;
   }
-
-
 }
-#endif
 
 static void
 init_paths (char *argv0)
@@ -455,7 +447,9 @@ init_paths (char *argv0)
   DPRINTF("%s (%s): haspath = %d\n", __FUNCTION__, argv0, haspath);
   if (haspath)
     {
-      bindir = strdup (lrealpath (argv0));
+      /* lrealpath() returns a malloc'd string — assign directly,
+       * don't strdup again (would leak the lrealpath result). */
+      bindir = lrealpath (argv0);
       found_bindir = 1;
     }
   else
@@ -548,7 +542,8 @@ init_paths (char *argv0)
   DPRINTF("%s():  exec_prefix = %s\n", __FUNCTION__, exec_prefix);
   DPRINTF("%s():  pkgdatadir  = %s\n", __FUNCTION__, pkgdatadir);
   DPRINTF("%s():  scmdatadir  = %s\n", __FUNCTION__, scmdatadir);
-  
+
+  atexit(destroy_paths);
 }
 
 


### PR DESCRIPTION
## Summary

Fixes #472 — static path strings in `init_paths()` (`src/project.c`) were never freed, causing valgrind to report 181 bytes definitely lost.

### Changes

1. **Enable `destroy_paths()`**: A cleanup function already existed but was `#if 0`'d out with a comment about "appeasing malloc debuggers." Removed the guard and registered it via `atexit()` so the paths are freed on normal exit.

2. **Fix double allocation**: `bindir = strdup(lrealpath(argv0))` leaked the `lrealpath()` return value since `lrealpath()` already returns a `malloc`'d string. Changed to `bindir = lrealpath(argv0)`.

### Verification

Valgrind before fix (via Xvfb with TinyScheme project loader):
```
definitely lost: 181 bytes in 2 blocks
```

Valgrind after fix:
```
definitely lost: 0 bytes in 0 blocks
```

Together with #470 (`gerbv_image_duplicate_image` leaks), gerbv now has **zero valgrind-reported leaks** across all tested code paths: Gerber parse/destroy, drill parse/destroy, PnP, aperture macros, multi-layer projects, RS274-X/DXF/drill export, and TinyScheme project file loading.

## Test plan

- [x] Builds clean with `-Werror`
- [x] No new test regressions (same 11 pre-existing golden-file mismatches)
- [x] Valgrind: 0 definitely lost bytes on TinyScheme project load path (Xvfb)
- [x] Valgrind: 0 definitely lost bytes on parse/destroy sweep