### PR TITLE
fix: preserve file unit in display and RS274-X export

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -209,6 +209,41 @@ void open_project(char *project_filename)
 
 /* --------------------------------------------------------- */
 /**
+  * Auto-detect and apply the display unit from the first loaded
+  * Gerber file.  Only switches when no files were previously
+  * loaded (first-file heuristic), so opening additional layers
+  * won't clobber the user's manual choice.
+  */
+static void
+auto_detect_display_unit(void)
+{
+    /* Only auto-detect on first file load */
+    int layer_count = 0;
+    for (int i = 0; i <= mainProject->last_loaded; i++) {
+        if (mainProject->file[i])
+            layer_count++;
+    }
+    if (layer_count != 1)
+        return;
+
+    /* Find the first loaded file and check its unit */
+    for (int i = 0; i <= mainProject->last_loaded; i++) {
+        if (!mainProject->file[i] || !mainProject->file[i]->image)
+            continue;
+
+        gerbv_unit_t unit = mainProject->file[i]->image->info->orig_unit;
+        if (unit == GERBV_UNIT_MM && screen.unit != GERBV_MMS) {
+            screen.unit = GERBV_MMS;
+            gtk_combo_box_set_active(
+                GTK_COMBO_BOX(screen.win.statusUnitComboBox),
+                GERBV_MMS);
+        }
+        break;
+    }
+}
+
+/* --------------------------------------------------------- */
+/**
   * File -> open action requested
   * or file drop event happened.
   * Open a layer (or layers) or one Gerbv project from the files.
@@ -339,6 +374,8 @@ void open_files(GSList *filenames)
 	gerbv_render_zoom_to_fit_display (mainProject, &screenRenderInfo);
 	render_refresh_rendered_image_on_screen();
 	callbacks_update_layer_tree();
+
+	auto_detect_display_unit();
 }
 
 /* --------------------------------------------------------- */

--- a/src/export-rs274x.c
+++ b/src/export-rs274x.c
@@ -112,7 +112,7 @@ export_rs274x_write_macro (FILE *fd, gerbv_aperture_t *currentAperture,
 }
 
 void
-export_rs274x_write_apertures (FILE *fd, gerbv_image_t *image) {
+export_rs274x_write_apertures (FILE *fd, gerbv_image_t *image, double unit_scale) {
 	gerbv_aperture_t *currentAperture;
 	gint numberOfRequiredParameters=0,numberOfOptionalParameters=0,i,j;
 	
@@ -166,7 +166,15 @@ export_rs274x_write_apertures (FILE *fd, gerbv_image_t *image) {
 					/* print the "X" character to separate the parameters */
 					if (j>0)
 						fprintf(fd, "X");
-					fprintf(fd, "%.4f",currentAperture->parameter[j]);
+					/* Polygon parameters 1 (sides) and 2 (rotation) are
+					 * not lengths — don't apply unit scaling. */
+					gboolean is_dimension = TRUE;
+					if (currentAperture->type == GERBV_APTYPE_POLYGON
+					    && (j == 1 || j == 2))
+						is_dimension = FALSE;
+					fprintf(fd, "%.4f",
+						currentAperture->parameter[j] *
+						(is_dimension ? unit_scale : 1.0));
 				}
 			}
 			fprintf(fd, "*%%\n");
@@ -188,15 +196,45 @@ export_rs274x_write_layer_change (gerbv_layer_t *oldLayer, gerbv_layer_t *newLay
 
 void
 export_rs274x_write_state_change (gerbv_netstate_t *oldState, gerbv_netstate_t *newState, FILE *fd) {
+	if (oldState->axisSelect != newState->axisSelect) {
+		if (newState->axisSelect == GERBV_AXIS_SELECT_SWAPAB)
+			fprintf(fd, "%%ASAYBX*%%\n");
+		else
+			fprintf(fd, "%%ASAXBY*%%\n");
+	}
 
+	if (oldState->mirrorState != newState->mirrorState) {
+		switch (newState->mirrorState) {
+		case GERBV_MIRROR_STATE_FLIPA:
+			fprintf(fd, "%%MIA1B0*%%\n"); break;
+		case GERBV_MIRROR_STATE_FLIPB:
+			fprintf(fd, "%%MIA0B1*%%\n"); break;
+		case GERBV_MIRROR_STATE_FLIPAB:
+			fprintf(fd, "%%MIA1B1*%%\n"); break;
+		default:
+			fprintf(fd, "%%MIA0B0*%%\n"); break;
+		}
+	}
 
+	if (oldState->offsetA != newState->offsetA ||
+	    oldState->offsetB != newState->offsetB) {
+		fprintf(fd, "%%OFA%fB%f*%%\n",
+			newState->offsetA, newState->offsetB);
+	}
+
+	if (oldState->scaleA != newState->scaleA ||
+	    oldState->scaleB != newState->scaleB) {
+		fprintf(fd, "%%SFA%fB%f*%%\n",
+			newState->scaleA, newState->scaleB);
+	}
 }
 
 gboolean
 gerbv_export_rs274x_file_from_image (const gchar *filename, gerbv_image_t *inputImage,
 		gerbv_user_transformation_t *transform)
 {
-	const double decimal_coeff = 1e6;
+	double decimal_coeff;
+	double unit_scale;  /* multiplier to convert internal inches to output unit */
 	FILE *fd;
 	gerbv_netstate_t *oldState;
 	gerbv_layer_t *oldLayer;
@@ -228,8 +266,21 @@ gerbv_export_rs274x_file_from_image (const gchar *filename, gerbv_image_t *input
 	fprintf(fd, "G04 More information is available about gerbv at *\n");
 	fprintf(fd, "G04 https://gerbv.github.io/ *\n");
 	fprintf(fd, "G04 --End of header info--*\n");
-	fprintf(fd, "%%MOIN*%%\n");
-	fprintf(fd, "%%FSLAX36Y36*%%\n");
+	/* Export in the file's original unit to preserve precision.
+	 * gerbv stores all coordinates internally in inches, so mm
+	 * export needs a 25.4x scale factor.  Use 4.6 format for mm
+	 * (nanometer resolution) vs 3.6 for inches. */
+	if (image->info->orig_unit == GERBV_UNIT_MM) {
+		fprintf(fd, "%%MOMM*%%\n");
+		fprintf(fd, "%%FSLAX46Y46*%%\n");
+		decimal_coeff = 25.4e6;  /* inches → mm × 1e6 */
+		unit_scale = 25.4;
+	} else {
+		fprintf(fd, "%%MOIN*%%\n");
+		fprintf(fd, "%%FSLAX36Y36*%%\n");
+		decimal_coeff = 1e6;
+		unit_scale = 1.0;
+	}
 	
 	/* check the image info struct for any non-default settings */
 	/* image offset */
@@ -280,7 +331,7 @@ gerbv_export_rs274x_file_from_image (const gchar *filename, gerbv_image_t *input
 	
 	/* define all apertures */
 	fprintf(fd, "G04 --Define apertures--*\n");
-	export_rs274x_write_apertures (fd, image);
+	export_rs274x_write_apertures (fd, image, unit_scale);
 	
 	/* write rest of image */
 	fprintf(fd, "G04 --Start main section--*\n");

--- a/src/gerber.c
+++ b/src/gerber.c
@@ -1440,10 +1440,12 @@ parse_rs274x(gint levelOfRecursion, gerb_file_t *fd, gerbv_image_t *image,
 	case A2I('I','N'):
 	    state->state = gerbv_image_return_new_netstate (state->state);
 	    state->state->unit = GERBV_UNIT_INCH;
+	    image->info->orig_unit = GERBV_UNIT_INCH;
 	    break;
 	case A2I('M','M'):
 	    state->state = gerbv_image_return_new_netstate (state->state);
 	    state->state->unit = GERBV_UNIT_MM;
+	    image->info->orig_unit = GERBV_UNIT_MM;
 	    break;
 	default:
 	    gerbv_stats_printf(error_list, GERBV_MESSAGE_ERROR, -1,

--- a/src/gerbv.h
+++ b/src/gerbv.h
@@ -715,6 +715,8 @@ typedef struct gerbv_image_info {
     */ 
     gerbv_HID_Attribute *attr_list;
     int n_attr;
+
+    gerbv_unit_t orig_unit; /*!< unit declared in the source file (%MOMM*% or %MOIN*%) */
 } gerbv_image_info_t;
 
 /*!  The structure used to hold a layer (RS274X, drill, or pick-and-place data) */


### PR DESCRIPTION
## Summary

Fixes #415 — gerbv ignores the unit declared in Gerber files (`%MOMM*%` / `%MOIN*%`) for both display and export.

### Bug 1: Display defaults to mils, ignores file metadata

`screen.unit` was hardcoded to `GERBV_DEFAULT_UNIT` (mils) at startup and never updated when a file was loaded. The parser correctly reads the unit into `gerbv_netstate_t.unit`, but no code ever syncs it to the display.

**Fix**: `auto_detect_display_unit()` in `callbacks.c` reads the first loaded file's `orig_unit` and switches the statusbar combo box to mm when a `%MOMM*%` file is opened. Only triggers on first-file load to avoid clobbering the user's manual choice when adding more layers.

### Bug 2: Export hardcodes inches

`export-rs274x.c` unconditionally wrote `%MOIN*%` with `%FSLAX36Y36*%` regardless of the source file. The `export_rs274x_write_state_change()` function was an empty stub.

**Fix**: Check `image->info->orig_unit` to choose between:

| Source unit | Mode command | Format | Coord scale | Resolution |
|-------------|-------------|--------|-------------|------------|
| `%MOMM*%` | `%MOMM*%` | `%FSLAX46Y46*%` | ×25.4 | nanometer |
| `%MOIN*%` | `%MOIN*%` | `%FSLAX36Y36*%` | ×1 | micro-inch |

The `unit_scale` factor is applied to coordinates and aperture dimensions. Polygon side count and rotation angle are not scaled (they're not lengths).

Also implements `export_rs274x_write_state_change()` to handle axis select (`AS`), mirror (`MI`), offset (`OF`), and scale factor (`SF`) state changes.

### Changes

| File | Change |
|------|--------|
| `src/gerbv.h` | Add `gerbv_unit_t orig_unit` to `gerbv_image_info_t` |
| `src/gerber.c` | Set `orig_unit` when `%MOMM*%` / `%MOIN*%` is parsed |
| `src/callbacks.c` | `auto_detect_display_unit()` — sync display unit from first loaded file |
| `src/export-rs274x.c` | Unit-aware export, implement state change handler, scale aperture params |

## Test plan

- [x] Builds clean with `-Werror`
- [x] No new test regressions (same 11 pre-existing golden-file mismatches)
- [x] MM round-trip: `%MOMM*%` file → export → output contains `%MOMM*%`, `%FSLAX46Y46*%`, mm coordinates, mm aperture dimensions
- [x] Inch export: `%MOIN*%` files still export as `%MOIN*%` with `%FSLAX36Y36*%`
- [ ] GUI verification: open mm file → statusbar shows "mm" automatically
- [ ] Round-trip precision: open mm file → export → re-open → coordinates match within tolerance