### PR TITLE
Fixed release problem that caused Windows MSYS2 and MacOS to not be r…

### DIFF
--- a/gerbv.github.io/ci/.gitignore
+++ b/gerbv.github.io/ci/.gitignore
@@ -2,5 +2,3 @@
 /*.RELEASE_COMMIT_SHORT
 /*.RELEASE_DATE
 /*.RELEASE_FILENAME
-/*.tar.gz
-/*.zip


### PR DESCRIPTION
…elased on home page

Root cause: gerbv.github.io/ci/.gitignore contained /*.zip and /*.tar.gz. This file gets deployed verbatim to the gh-pages branch of gerbv/gerbv.github.io. When JamesIves/github-pages-deploy-action commits files to that branch, git respects the deployed .gitignore and silently excludes zip files from the commit. The index.html links to them correctly (generated locally from downloaded CI artifacts before deployment), but the actual files never land on GitHub Pages → 404.

The fix: Removed /*.zip and /*.tar.gz from ci/.gitignore. The RELEASE_* patterns remain to keep generated metadata out of the main gerbv/gerbv repo. On the next push to develop, the deploy action will see the updated .gitignore (no zip exclusion) in the working tree and properly commit the zip files to gh-pages.

Closes #480 