### PR TITLE
Github announced they will switch Windows latest from 2025 to 2026

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,7 +262,6 @@ jobs:
           ninja:p
           pkgconf:p
           gtk2:p
-          gtkmm:p
           gettext-tools:p
           imagemagick:p
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -241,7 +241,7 @@ jobs:
         if-no-files-found: error
 
   ci-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
This is a small update to github workflow to set
  runs-on: windows-2025-vs2026
in our MSYS2 compilation to see if it still compiles. This project is plain C, so there should be no regressions. But you never know.

Github announced the migration will start on June 8th, 2026.