### PR TITLE
Fix two minor compile issues

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -32,6 +32,9 @@ check_function_exists(canonicalize_file_name HAVE_CANONICALIZE_FILE_NAME)
 check_function_exists(dcgettext HAVE_DCGETTEXT)
 check_function_exists(iconv HAVE_ICONV)
 
+include(CheckSymbolExists)
+check_symbol_exists(canonicalize_file_name stdlib.h HAVE_CANONICALIZE_FILE_NAME_DECL)
+
 include(CheckLibraryExists)
 check_library_exists(m pow "" HAVE_LIBM)
 check_library_exists(dl dlopen "" HAVE_LIBDL)

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -38,6 +38,9 @@
 /* Define to 1 if you have the `canonicalize_file_name' function. */
 #cmakedefine HAVE_CANONICALIZE_FILE_NAME @HAVE_CANONICALIZE_FILE_NAME@
 
+/* Define to 1 if canonicalize_file_name is declared in system header files. */
+#cmakedefine HAVE_CANONICALIZE_FILE_NAME_DECL @HAVE_CANONICALIZE_FILE_NAME_DECL@
+
 /* Define to 1 if you have the Mac OS X function CFLocaleCopyCurrent in the
    CoreFoundation framework. */
 #undef HAVE_CFLOCALECOPYCURRENT
@@ -120,9 +123,6 @@
 
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 //#undef LT_OBJDIR
-
-/* Define if canonicalize_file_name is not declared in system header files. */
-#undef NEED_DECLARATION_CANONICALIZE_FILE_NAME
 
 /* Name of package */
 #define PACKAGE "@PACKAGE@"

--- a/src/lrealpath.c
+++ b/src/lrealpath.c
@@ -53,7 +53,7 @@ components will be simplified.  The returned value will be allocated using
 
 /* On GNU libc systems the declaration is only visible with _GNU_SOURCE.  */
 #if defined(HAVE_CANONICALIZE_FILE_NAME) \
-    && defined(NEED_DECLARATION_CANONICALIZE_FILE_NAME)
+    && ! defined(HAVE_CANONICALIZE_FILE_NAME_DECL)
 extern char *canonicalize_file_name (const char *);
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -1299,15 +1299,15 @@ getopt_configured(int argc, char * const argv[], const char *optstring,
 static int
 getopt_lengh_unit(const char *optarg, double *input_div, gerbv_screen_t *screen)
 {
-	if (strncasecmp(optarg, "mm", 2) == 0) {
+	if (g_ascii_strncasecmp(optarg, "mm", 2) == 0) {
 		*input_div = 25.4;
 		screen->unit = GERBV_MMS;
 		screen->unit_is_from_cmdline = TRUE;
-	} else if (strncasecmp(optarg, "mil", 3) == 0) {
+	} else if (g_ascii_strncasecmp(optarg, "mil", 3) == 0) {
 		*input_div = 1000.0;
 		screen->unit = GERBV_MILS;
 		screen->unit_is_from_cmdline = TRUE;
-	} else if (strncasecmp(optarg, "inch", 4) == 0) {
+	} else if (g_ascii_strncasecmp(optarg, "inch", 4) == 0) {
 		*input_div = 1.0;
 		screen->unit = GERBV_INS;
 		screen->unit_is_from_cmdline = TRUE;


### PR DESCRIPTION
One fix is for the use of strncasecmp() without a proper include in main.c (an alternative fix is described in the commit), the other improves auto-detection for canonicalize_file_name on glibc systems where the user did not specify -D_GNU_SOURCE such that in the case of presence of the function in the library, but not in the header files, the internal declaration is automatically enabled.