### PR TITLE
Remove unused gtkmm dependency from Windows CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,7 +262,6 @@ jobs:
           ninja:p
           pkgconf:p
           gtk2:p
-          gtkmm:p
           gettext-tools:p
           imagemagick:p
 


### PR DESCRIPTION
MSYS2 dropped the unversioned mingw-w64-ucrt-x86_64-gtkmm package (only gtkmm3 and gtkmm-4.0 remain), breaking pacboy install on ci-windows: "target not found: mingw-w64-ucrt-x86_64-gtkmm".

gtkmm is not referenced anywhere in the build (grep across CMakeLists.txt confirms no usage), so drop the dead dependency instead of chasing a renamed package.